### PR TITLE
"User Picker" editor

### DIFF
--- a/.github/IDEAS.md
+++ b/.github/IDEAS.md
@@ -26,9 +26,6 @@
   For a toolbar menu, maybe add options using the action overlay UI?
   https://github.com/umbraco/Umbraco-CMS/blob/release-8.1.0/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm-action.html
 
-- User Picker
-  The default User Picker property-editor is a plain dropdown list, (it's rubbish), but in the Users section, the Role editor has a really nice User picker, with overlay.
-
 - Dimensions - Width x Height combo
   https://github.com/umbraco/Umbraco-CMS/blob/release-8.1.0/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html#L29-L34
 

--- a/src/Umbraco.Community.Contentment/AjaxMin.xml
+++ b/src/Umbraco.Community.Contentment/AjaxMin.xml
@@ -24,6 +24,7 @@
         <input path="DataEditors\RadioButtonList\radio-button-list.js" />
         <input path="DataEditors\RenderMacro\render-macro.js" />
         <input path="DataEditors\Toggles\toggles.js" />
+        <input path="DataEditors\UserPicker\user-picker.js" />
         <input path="DataEditors\_\_dev-mode.js" />
     </output>
     <output path="contentment.css">

--- a/src/Umbraco.Community.Contentment/DataEditors/UserPicker/UserPickerConfigurationEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/UserPicker/UserPickerConfigurationEditor.cs
@@ -1,0 +1,20 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    public class UserPickerConfigurationEditor : ConfigurationEditor
+    {
+        public UserPickerConfigurationEditor()
+            : base()
+        {
+            Fields.AddMaxItems();
+            Fields.AddDisableSorting();
+            Fields.AddHideLabel();
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/UserPicker/UserPickerDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/UserPicker/UserPickerDataEditor.cs
@@ -1,0 +1,34 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using Umbraco.Core.Logging;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    [DataEditor(
+        DataEditorAlias,
+        EditorType.PropertyValue | EditorType.MacroParameter,
+        DataEditorName,
+        DataEditorViewPath,
+        ValueType = ValueTypes.String,
+        Group = "People",
+        Icon = DataEditorIcon)]
+    public class UserPickerDataEditor : DataEditor
+    {
+        internal const string DataEditorAlias = Constants.Internals.DataEditorAliasPrefix + "UserPicker";
+        internal const string DataEditorName = Constants.Internals.DataEditorNamePrefix + "User Picker";
+        internal const string DataEditorViewPath = Constants.Internals.EditorsPathRoot + "user-picker.html";
+        internal const string DataEditorIcon = "icon-user-females-alt";
+
+        public UserPickerDataEditor(ILogger logger)
+            : base(logger)
+        { }
+
+        protected override IConfigurationEditor CreateConfigurationEditor() => new UserPickerConfigurationEditor();
+
+        protected override IDataValueEditor CreateValueEditor() => new HideLabelDataValueEditor(Attribute);
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/UserPicker/user-picker.html
+++ b/src/Umbraco.Community.Contentment/DataEditors/UserPicker/user-picker.html
@@ -1,0 +1,18 @@
+﻿<!-- Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+   - This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+<div ng-controller="Umbraco.Community.Contentment.DataEditors.UserPicker.Controller as vm">
+    <div class="umb-property-editor--limit-width" ui-sortable="vm.sortableOptions" ng-model="vm.items">
+        <umb-user-preview ng-repeat="user in vm.items"
+                          name="user.name"
+                          avatars="user.avatars"
+                          allow-remove="vm.allowRemove"
+                          on-remove="vm.remove($index)">
+        </umb-user-preview>
+    </div>
+    <a class="umb-node-preview-add" href="" ng-click="vm.add()" ng-if="vm.allowAdd" prevent-default>
+        <localize key="general_add">Add</localize>
+    </a>
+</div>

--- a/src/Umbraco.Community.Contentment/DataEditors/UserPicker/user-picker.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/UserPicker/user-picker.js
@@ -1,0 +1,117 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.UserPicker.Controller", [
+    "$scope",
+    "editorService",
+    "entityResource",
+    "usersResource",
+    function ($scope, editorService, entityResource, usersResource) {
+
+        console.log("user-picker.model", $scope.model);
+
+        var defaultConfig = {
+            disableSorting: 0,
+            maxItems: 0,
+        };
+        var config = angular.extend({}, defaultConfig, $scope.model.config);
+
+        var vm = this;
+
+        function init() {
+
+            $scope.model.value = $scope.model.value || [];
+
+            vm.sortable = Object.toBoolean(config.disableSorting) === false && (config.maxItems !== 1 && config.maxItems !== "1");
+
+            vm.sortableOptions = {
+                axis: "y",
+                containment: "parent",
+                cursor: "move",
+                disabled: vm.sortable === false,
+                opacity: 0.7,
+                scroll: true,
+                tolerance: "pointer",
+                stop: function (e, ui) {
+                    $scope.model.value = _.map(vm.items, function (x) { return x.id });
+                    setDirty();
+                }
+            };
+
+            vm.allowAdd = true;
+            vm.allowRemove = true;
+
+            vm.add = add;
+            vm.remove = remove;
+
+            vm.items = [];
+
+            // TODO: [LK:2019-08-16] Querying for each user (using `usersResource.getUser`) is inefficient.
+            // Using the `entityResource.getAll("User")` is better, but doesn't return the `avatars`.
+
+            //if ($scope.model.value.length > 0) {
+            //    entityResource.getAll("User").then(function (users) {
+            //        _.each($scope.model.value, function (id) {
+            //            var user = _.find(users, function (x) { return x.id === id });
+            //            if (user) {
+            //                vm.items.push(user);
+            //            }
+            //        });
+            //    });
+            //}
+
+            if ($scope.model.value.length > 0) {
+                _.each($scope.model.value, function (v) {
+                    usersResource.getUser(v).then(function (user) {
+                        vm.items.push(user);
+                    });
+                });
+            }
+        };
+
+        function add() {
+
+            var oldSelection = angular.copy(vm.items);
+            var userPicker = {
+                selection: vm.items,
+                submit: function () {
+
+                    $scope.model.value = _.map(vm.items, function (x) { return x.id });
+
+                    setDirty();
+
+                    editorService.close();
+                },
+                close: function () {
+                    vm.items = oldSelection;
+                    editorService.close();
+                }
+            };
+
+            editorService.userPicker(userPicker);
+
+        };
+
+        function remove($index) {
+
+            vm.items.splice($index, 1);
+            $scope.model.value.splice($index, 1);
+
+            if ((config.maxItems === 0 || config.maxItems === "0") || $scope.model.value.length < config.maxItems) {
+                vm.allowAdd = true;
+            }
+
+            setDirty();
+        };
+
+        function setDirty() {
+            if ($scope.propertyForm) {
+                $scope.propertyForm.$setDirty();
+            }
+        };
+
+        init();
+    }
+]);

--- a/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
+++ b/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
@@ -319,6 +319,8 @@
     <Compile Include="DataEditors\ConfigurationEditor\Serialization\ConfigurationFieldContractResolver.cs" />
     <Compile Include="DataEditors\DataList\DataListValueConverter.cs" />
     <Compile Include="DataEditors\DropdownList\AllowEmptyConfigurationField.cs" />
+    <Compile Include="DataEditors\UserPicker\UserPickerConfigurationEditor.cs" />
+    <Compile Include="DataEditors\UserPicker\UserPickerDataEditor.cs" />
     <Compile Include="DataEditors\_\ShowDescriptionsConfigurationField.cs" />
     <Compile Include="DataEditors\Cards\CardsDataEditor.cs" />
     <Compile Include="DataEditors\HideLabel\ConfigurationFieldExtensions.cs" />
@@ -402,6 +404,8 @@
     <Content Include="DataEditors\RadioButtonList\radio-button-list.css" />
     <Content Include="DataEditors\Toggles\toggles.js" />
     <Content Include="DataEditors\Toggles\toggles.html" />
+    <Content Include="DataEditors\UserPicker\user-picker.html" />
+    <Content Include="DataEditors\UserPicker\user-picker.js" />
     <Content Include="DataEditors\_\_json-editor.html" />
     <Content Include="DataEditors\_\_dev-mode.html" />
     <Content Include="DataEditors\_\_dev-mode.js" />


### PR DESCRIPTION
Adds a "User Picker" property-editor.  Reuses the user picker component from the User Role editor section. A much better experience than the default core "User Picker" property-editor, which is a dropdown list.