### PR TITLE
IPublishedContent Serialization

### DIFF
--- a/src/Our.Umbraco.Contentment/Web/Serialization/PublishedContentContractResolver.cs
+++ b/src/Our.Umbraco.Contentment/Web/Serialization/PublishedContentContractResolver.cs
@@ -11,6 +11,7 @@
  * has been licensed. I'll assume it's available under MIT license. */
 
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -21,39 +22,45 @@ namespace Our.Umbraco.Contentment
     {
         public static readonly PublishedContentContractResolver Instance = new PublishedContentContractResolver();
 
+        private readonly HashSet<string> _excludedProperties;
+
+        public PublishedContentContractResolver()
+        {
+            _excludedProperties = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase)
+            {
+                "Children",
+                "ChildrenForAllCultures",
+                "CompositionAliases",
+                "ContentSet",
+                "ContentType",
+                "CreateDate",
+                "CreatorId",
+                "CreatorName",
+                "DocumentTypeId",
+                "IsDraft",
+                "ItemType",
+                "ObjectContent",
+                "Parent",
+                "Properties",
+                "PropertyTypes",
+                "SortOrder",
+                "TemplateId",
+                "UpdateDate",
+                "Url",
+                "Version",
+                "WriterId",
+                "WriterName",
+            };
+        }
+
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {
             var property = base.CreateProperty(member, memberSerialization);
 
-            property.ShouldSerialize = instance =>
+
+            property.ShouldSerialize = _ =>
             {
-                if (property.PropertyName == "CompositionAliases") return false;
-                if (property.PropertyName == "ContentSet") return false;
-                if (property.PropertyName == "PropertyTypes") return false;
-                if (property.PropertyName == "ObjectContent") return false;
-                if (property.PropertyName == "Properties") return false;
-                if (property.PropertyName == "Parent") return false;
-                if (property.PropertyName == "Children") return false;
-                if (property.PropertyName == "ChildrenForAllCultures") return false;
-                if (property.PropertyName == "DocumentTypeId") return false;
-                if (property.PropertyName == "WriterName") return false;
-                if (property.PropertyName == "CreatorName") return false;
-                if (property.PropertyName == "WriterId") return false;
-                if (property.PropertyName == "CreatorId") return false;
-                if (property.PropertyName == "CreateDate") return false;
-                if (property.PropertyName == "UpdateDate") return false;
-                if (property.PropertyName == "Version") return false;
-                if (property.PropertyName == "SortOrder") return false;
-                if (property.PropertyName == "TemplateId") return false;
-                if (property.PropertyName == "IsDraft") return false;
-                if (property.PropertyName == "ItemType") return false;
-                if (property.PropertyName == "ContentType") return false;
-                if (property.PropertyName == "Url") return false;
-                if (property.PropertyName == "ContentSet") return false;
-                //ADD CUSTOM OVERRRIDES AFTER THIS IN THE ABOVE FORMAT
-
-
-                return true;
+                return _excludedProperties.Contains(property.PropertyName) == false;
             };
 
             return property;

--- a/src/Our.Umbraco.Contentment/Web/Serialization/PublishedContentContractResolver.cs
+++ b/src/Our.Umbraco.Contentment/Web/Serialization/PublishedContentContractResolver.cs
@@ -1,0 +1,71 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+/* This code has been derived from Rasmus Fjord's code, supplied on an
+ * Our Umbraco forum post:
+ * https://our.umbraco.com/forum/umbraco-8/98381-serializing-an-publishedcontentmodel-modelsbuilder-model-in-v8#comment-310148
+ * From searching GitHub, I also found René Pjengaard's code:
+ * https://github.com/rpjengaard/merchelloshop/blob/master/dev/code/Json/Resolvers/PublishedContentContractResolver.cs
+ * It is unknown (to me) who the original author is, and how the code
+ * has been licensed. I'll assume it's available under MIT license. */
+
+using System;
+using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Our.Umbraco.Contentment
+{
+    public class PublishedContentContractResolver : DefaultContractResolver
+    {
+        public static readonly PublishedContentContractResolver Instance = new PublishedContentContractResolver();
+
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var property = base.CreateProperty(member, memberSerialization);
+
+            property.ShouldSerialize = instance =>
+            {
+                if (property.PropertyName == "CompositionAliases") return false;
+                if (property.PropertyName == "ContentSet") return false;
+                if (property.PropertyName == "PropertyTypes") return false;
+                if (property.PropertyName == "ObjectContent") return false;
+                if (property.PropertyName == "Properties") return false;
+                if (property.PropertyName == "Parent") return false;
+                if (property.PropertyName == "Children") return false;
+                if (property.PropertyName == "ChildrenForAllCultures") return false;
+                if (property.PropertyName == "DocumentTypeId") return false;
+                if (property.PropertyName == "WriterName") return false;
+                if (property.PropertyName == "CreatorName") return false;
+                if (property.PropertyName == "WriterId") return false;
+                if (property.PropertyName == "CreatorId") return false;
+                if (property.PropertyName == "CreateDate") return false;
+                if (property.PropertyName == "UpdateDate") return false;
+                if (property.PropertyName == "Version") return false;
+                if (property.PropertyName == "SortOrder") return false;
+                if (property.PropertyName == "TemplateId") return false;
+                if (property.PropertyName == "IsDraft") return false;
+                if (property.PropertyName == "ItemType") return false;
+                if (property.PropertyName == "ContentType") return false;
+                if (property.PropertyName == "Url") return false;
+                if (property.PropertyName == "ContentSet") return false;
+                //ADD CUSTOM OVERRRIDES AFTER THIS IN THE ABOVE FORMAT
+
+                //making people on the other end of my api happy 
+                //property.PropertyName = StringUtils.ToCamelCase(property.PropertyName);
+
+                return true;
+            };
+
+            return property;
+        }
+
+        protected override JsonContract CreateContract(Type objectType)
+        {
+            var contract = base.CreateContract(objectType);
+
+            return contract;
+        }
+    }
+}

--- a/src/Our.Umbraco.Contentment/Web/Serialization/PublishedContentContractResolver.cs
+++ b/src/Our.Umbraco.Contentment/Web/Serialization/PublishedContentContractResolver.cs
@@ -57,6 +57,7 @@ namespace Our.Umbraco.Contentment
         {
             var property = base.CreateProperty(member, memberSerialization);
 
+            // TODO: [LK:2019-08-01] Check that the declaring type inherits from `IPublishedContent`.
 
             property.ShouldSerialize = _ =>
             {
@@ -64,13 +65,6 @@ namespace Our.Umbraco.Contentment
             };
 
             return property;
-        }
-
-        protected override JsonContract CreateContract(Type objectType)
-        {
-            var contract = base.CreateContract(objectType);
-
-            return contract;
         }
     }
 }

--- a/src/Our.Umbraco.Contentment/Web/Serialization/PublishedContentContractResolver.cs
+++ b/src/Our.Umbraco.Contentment/Web/Serialization/PublishedContentContractResolver.cs
@@ -17,7 +17,7 @@ using Newtonsoft.Json.Serialization;
 
 namespace Our.Umbraco.Contentment
 {
-    public class PublishedContentContractResolver : DefaultContractResolver
+    public class PublishedContentContractResolver : CamelCasePropertyNamesContractResolver
     {
         public static readonly PublishedContentContractResolver Instance = new PublishedContentContractResolver();
 
@@ -52,8 +52,6 @@ namespace Our.Umbraco.Contentment
                 if (property.PropertyName == "ContentSet") return false;
                 //ADD CUSTOM OVERRRIDES AFTER THIS IN THE ABOVE FORMAT
 
-                //making people on the other end of my api happy 
-                //property.PropertyName = StringUtils.ToCamelCase(property.PropertyName);
 
                 return true;
             };

--- a/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
+++ b/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
@@ -400,9 +400,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Trees\ContentmentTreeController.cs" />
     <Compile Include="Web\Controllers\EnumDataListSourceApiController.cs" />
-    <Compile Include="Web\Serialization\PublishedContentContractResolver.cs" />
     <Compile Include="Web\PublishedCache\DetachedPublishedElement.cs" />
     <Compile Include="Web\PublishedCache\DetachedPublishedProperty.cs" />
+    <Compile Include="Web\Serialization\PublishedContentContractResolver.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
+++ b/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
@@ -400,6 +400,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Trees\ContentmentTreeController.cs" />
     <Compile Include="Web\Controllers\EnumDataListSourceApiController.cs" />
+    <Compile Include="Web\Serialization\PublishedContentContractResolver.cs" />
     <Compile Include="Web\PublishedCache\DetachedPublishedElement.cs" />
     <Compile Include="Web\PublishedCache\DetachedPublishedProperty.cs" />
   </ItemGroup>


### PR DESCRIPTION
Serializing `IPublishedContent` was always tricky in Umbraco v7.x, due to the various self-referencing loops in properties. Every time I dealt with serializing it a different way.

After seeing this forum post: <https://our.umbraco.com/forum/umbraco-8/98381-serializing-an-publishedcontentmodel-modelsbuilder-model-in-v8#comment-310148>, I decided to adapt the code for use in Contentment.

I haven't decided how useful this will be for the project yet.