### PR TITLE
"Transclude" editor

### DIFF
--- a/.github/IDEAS.md
+++ b/.github/IDEAS.md
@@ -12,9 +12,6 @@
 - Textbox
   Customizable textbox, Placeholder text, Default value, Prefix / suffix (input groups), Char limit, Hide label, Html5 types, Data list
 
-- Remote Content
-  Enter a URL into a textbox, the value-converter will request the URL, cache and return its contents as the property value.
-
 - Local Content
   Enable editing of a local file's content, e.g. robots.txt
   Something similar to this, https://our.umbraco.com/packages/website-utilities/umbraco-content-files/, but not as tied to the doctype.

--- a/src/Umbraco.Community.Contentment/DataEditors/Transclude/TranscludeDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/Transclude/TranscludeDataEditor.cs
@@ -1,0 +1,41 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using Umbraco.Core.Logging;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    [DataEditor(
+        DataEditorAlias,
+#if DEBUG
+        EditorType.PropertyValue, // NOTE: IsWorkInProgress [LK]
+#else
+        EditorType.Nothing,
+#endif
+        DataEditorName,
+        DataEditorViewPath,
+        ValueType = ValueTypes.String,
+        Group = Constants.Conventions.PropertyGroups.Common,
+        Icon = DataEditorIcon)]
+    public class TranscludeDataEditor : DataEditor
+    {
+        internal const string DataEditorAlias = Constants.Internals.DataEditorAliasPrefix + "Transclude";
+        internal const string DataEditorName = Constants.Internals.DataEditorNamePrefix + "Transclude";
+        internal const string DataEditorViewPath = Constants.Internals.EditorsPathRoot + "transclude.html";
+        internal const string DataEditorIcon = "icon-globe-alt";
+
+        public TranscludeDataEditor(ILogger logger)
+            : base(logger)
+        { }
+
+        // TODO: [LK:2019-07-09] Consider enhanced UI for this editor.
+        // Marc did one for RSS feeds... https://our.umbraco.com/packages/backoffice-extensions/rss-feed-url/
+        // It could handle RSS feeds, Markdown transformations, XML/XSLT?
+        // or just return the string contents and let the frontend implementor deal with it?
+
+        protected override IDataValueEditor CreateValueEditor() => new HideLabelDataValueEditor(Attribute);
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/Transclude/TranscludeValueConverter.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/Transclude/TranscludeValueConverter.cs
@@ -1,0 +1,35 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System;
+using System.Net;
+using Umbraco.Core;
+using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    public class TranscludeValueConverter : PropertyValueConverterBase
+    {
+        public override bool IsConverter(IPublishedPropertyType propertyType) => propertyType.EditorAlias.InvariantEquals(TranscludeDataEditor.DataEditorAlias);
+
+        public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Element;
+
+        public override Type GetPropertyValueType(IPublishedPropertyType propertyType) => typeof(string);
+
+        public override object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
+        {
+            if (source is string value && string.IsNullOrWhiteSpace(value) == false)
+            {
+                using (var client = new WebClient())
+                {
+                    return client.DownloadString(value);
+                }
+            }
+
+            return base.ConvertSourceToIntermediate(owner, propertyType, source, preview);
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/Transclude/transclude.html
+++ b/src/Umbraco.Community.Contentment/DataEditors/Transclude/transclude.html
@@ -1,0 +1,8 @@
+﻿<!-- Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+   - This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+<div>
+    <input type="url" placeholder="https://example.com" class="umb-property-editor umb-textstring" ng-model="model.value">
+</div>

--- a/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
+++ b/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
@@ -319,6 +319,8 @@
     <Compile Include="DataEditors\ConfigurationEditor\Serialization\ConfigurationFieldContractResolver.cs" />
     <Compile Include="DataEditors\DataList\DataListValueConverter.cs" />
     <Compile Include="DataEditors\DropdownList\AllowEmptyConfigurationField.cs" />
+    <Compile Include="DataEditors\Transclude\TranscludeDataEditor.cs" />
+    <Compile Include="DataEditors\Transclude\TranscludeValueConverter.cs" />
     <Compile Include="DataEditors\_\ShowDescriptionsConfigurationField.cs" />
     <Compile Include="DataEditors\Cards\CardsDataEditor.cs" />
     <Compile Include="DataEditors\HideLabel\ConfigurationFieldExtensions.cs" />
@@ -402,6 +404,7 @@
     <Content Include="DataEditors\RadioButtonList\radio-button-list.css" />
     <Content Include="DataEditors\Toggles\toggles.js" />
     <Content Include="DataEditors\Toggles\toggles.html" />
+    <Content Include="DataEditors\Transclude\transclude.html" />
     <Content Include="DataEditors\_\_json-editor.html" />
     <Content Include="DataEditors\_\_dev-mode.html" />
     <Content Include="DataEditors\_\_dev-mode.js" />


### PR DESCRIPTION
Adds "Transclude" editor.

The idea here is to enter a URL into a textbox, the value-converter will request the URL, cache and return its contents as the property value.

This could be useful if a content-editor would like to pull in raw text/HTML content into a page.

Beyond that, I'd expect we'd be treading into [Denina script](https://denina.org/) territory.