### PR TITLE
"Social Links" (and "Social Picker") editor

### DIFF
--- a/.github/IDEAS.md
+++ b/.github/IDEAS.md
@@ -58,5 +58,4 @@
 
 - Text Input - Change Font-Size within Input Field Based on Length (similar to Facebook's post experience, after 85 chars)
   - https://web-design-weekly.com/snippets/change-font-size-within-input-field-based-on-length/
-
 - 

--- a/src/Umbraco.Community.Contentment/Composing/ContentmentComposer.cs
+++ b/src/Umbraco.Community.Contentment/Composing/ContentmentComposer.cs
@@ -33,6 +33,8 @@ namespace Umbraco.Community.Contentment.Composing
                     .Exclude<ItemPickerDataEditor>()
                     .Exclude<MacroPickerDataEditor>()
                     .Exclude<RadioButtonListDataEditor>()
+                    .Exclude<SocialLinksDataEditor>()
+                    .Exclude<SocialPickerDataEditor>()
                     .Exclude<TextInputDataEditor>()
                     .Exclude<TogglesDataEditor>()
             ;
@@ -49,6 +51,8 @@ namespace Umbraco.Community.Contentment.Composing
                     .Remove<ItemPickerValueConverter>()
                     .Remove<MacroPickerValueConverter>()
                     .Remove<RadioButtonListValueConverter>()
+                    .Remove<SocialLinksValueConverter>()
+                    .Remove<SocialPickerValueConverter>()
             ;
 #endif
         }

--- a/src/Umbraco.Community.Contentment/DataEditors/SocialLinks/SocialLink.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/SocialLinks/SocialLink.cs
@@ -1,0 +1,20 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+    public class SocialLink
+    {
+        public string Network { get; set; }
+
+        public string Name { get; set; }
+
+        public string Url { get; set; }
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/SocialLinks/SocialLinksDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/SocialLinks/SocialLinksDataEditor.cs
@@ -1,0 +1,35 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using Umbraco.Core.Logging;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    [DataEditor(
+        DataEditorAlias,
+        EditorType.PropertyValue,
+        DataEditorName,
+        DataEditorViewPath,
+        ValueType = ValueTypes.Json,
+        Group = Core.Constants.PropertyEditors.Groups.Pickers,
+#if DEBUG
+        Icon = DataEditorIcon + " color-red"
+#else
+        Icon = DataEditorIcon
+#endif
+        )]
+    public class SocialLinksDataEditor : DataEditor
+    {
+        internal const string DataEditorAlias = Constants.Internals.DataEditorAliasPrefix + "SocialLinks";
+        internal const string DataEditorName = Constants.Internals.DataEditorNamePrefix + "Social Links";
+        internal const string DataEditorViewPath = Constants.Internals.EditorsPathRoot + "social-links.html";
+        internal const string DataEditorIcon = "icon-molecular-network";
+
+        public SocialLinksDataEditor(ILogger logger)
+            : base(logger)
+        { }
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/SocialLinks/SocialLinksValueConverter.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/SocialLinks/SocialLinksValueConverter.cs
@@ -1,0 +1,33 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Umbraco.Core;
+using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    public class SocialLinksValueConverter : PropertyValueConverterBase
+    {
+        public override bool IsConverter(IPublishedPropertyType propertyType) => propertyType.EditorAlias.InvariantEquals(SocialLinksDataEditor.DataEditorAlias);
+
+        public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Element;
+
+        public override Type GetPropertyValueType(IPublishedPropertyType propertyType) => typeof(IEnumerable<SocialLink>);
+
+        public override object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
+        {
+            if (source is string value)
+            {
+                return JsonConvert.DeserializeObject<IEnumerable<SocialLink>>(value);
+            }
+
+            return base.ConvertSourceToIntermediate(owner, propertyType, source, preview);
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/SocialLinks/social-links.css
+++ b/src/Umbraco.Community.Contentment/DataEditors/SocialLinks/social-links.css
@@ -1,0 +1,16 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+.contentment.umb-multiple-textbox .btn-social-icon {
+    margin-right: 5px;
+}
+
+.contentment.umb-multiple-textbox .lk-textstring-wrapper {
+    max-width: 761px;
+}
+
+    .contentment.umb-multiple-textbox .lk-textstring-wrapper .umb-textstring {
+        width: 378px;
+    }

--- a/src/Umbraco.Community.Contentment/DataEditors/SocialLinks/social-links.html
+++ b/src/Umbraco.Community.Contentment/DataEditors/SocialLinks/social-links.html
@@ -1,0 +1,39 @@
+﻿<!-- Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+   - This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+<div class="contentment umb-property-editor umb-multiple-textbox" ng-controller="Umbraco.Community.Contentment.DataEditors.SocialLinks.Controller as vm">
+    <div ui-sortable="vm.sortableOptions" ng-model="model.value">
+        <div class="flex flex-wrap textbox-wrapper" ng-repeat="item in model.value track by $index">
+            <a href="" class="btn btn-social-icon" ng-class="item.button" ng-click="vm.pick($index)" prevent-default>
+                <i ng-class="item.icon"></i>
+            </a>
+            <div class="lk-textstring-wrapper flx-i">
+                <input type="text" class="umb-textstring textstring" ng-model="item.name" />
+                <input type="text" class="umb-textstring textstring" ng-model="item.url" />
+            </div>
+            <div class="icon-wrapper">
+                <i class="icon icon-navigation handle"></i>
+                <div class="umb-multiple-textbox__confirm">
+                    <button type="button"
+                            class="umb-multiple-textbox__confirm-action"
+                            ng-click="vm.showPrompt($index)"
+                            prevet-default
+                            localize="title"
+                            title="@content_removeTextBox">
+                        <i class="icon-trash"></i>
+                    </button>
+                    <umb-confirm-action ng-if="vm.promptIsVisible === $index"
+                                        direction="left"
+                                        on-confirm="vm.remove($index)"
+                                        on-cancel="vm.hidePrompt()">
+                    </umb-confirm-action>
+                </div>
+            </div>
+        </div>
+    </div>
+    <a href="" class="add-link" ng-click="vm.add()" prevent-default>
+        <localize key="general_add">Add</localize>
+    </a>
+</div>

--- a/src/Umbraco.Community.Contentment/DataEditors/SocialLinks/social-links.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/SocialLinks/social-links.js
@@ -1,0 +1,110 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.SocialLinks.Controller", [
+    "$scope",
+    "editorService",
+    function ($scope, editorService) {
+
+        // console.log("social-links.model", $scope.model);
+
+        var defaultConfig = {
+            overlayView: "/App_Plugins/Contentment/editors/social-picker.overlay.html"
+        };
+        var config = angular.extend({}, defaultConfig, $scope.model.config);
+
+        var vm = this;
+
+        function init() {
+
+            $scope.model.value = $scope.model.value || [];
+
+            vm.sortableOptions = {
+                axis: "y",
+                containment: "parent",
+                cursor: "move",
+                handle: ".handle",
+                opacity: 0.7,
+                scroll: true,
+                tolerance: "pointer",
+                stop: function (e, ui) {
+                    setDirty();
+                }
+            };
+
+            vm.promptIsVisible = -1;
+            vm.showPrompt = showPrompt;
+            vm.hidePrompt = hidePrompt;
+
+            vm.add = add;
+            vm.pick = pick;
+            vm.remove = remove;
+        };
+
+        function add() {
+            $scope.model.value.push({
+                network: "",
+                button: "btn-lk-add",
+                icon: "icon-add",
+                name: "",
+                url: "",
+            });
+            pick($scope.model.value.length - 1);
+        };
+
+        function pick($index) {
+
+            var item = $scope.model.value[$index];
+
+            editorService.open({
+                size: "small",
+                view: config.overlayView,
+                value: item,
+                submit: function (model) {
+
+                    item.network = model.network;
+                    item.button = "btn-" + model.network;
+                    item.icon = "fa fa-" + (model.icon || model.network);
+
+                    if (item.name === '') {
+                        item.name = model.name;
+                    }
+
+                    if (item.url === '') {
+                        item.url = model.url;
+                    }
+
+                    setDirty();
+
+                    editorService.close();
+                },
+                close: function () {
+                    editorService.close();
+                }
+            });
+        };
+
+        function remove($index) {
+            vm.hidePrompt();
+            $scope.model.value.splice($index, 1);
+        };
+
+        function showPrompt($index) {
+            vm.promptIsVisible = $index;
+        };
+
+        function hidePrompt() {
+            vm.promptIsVisible = -1;
+        };
+
+        function setDirty() {
+            if ($scope.propertyForm) {
+                $scope.propertyForm.$setDirty();
+            }
+        };
+
+        init();
+    }
+]);

--- a/src/Umbraco.Community.Contentment/DataEditors/SocialPicker/SocialPickerDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/SocialPicker/SocialPickerDataEditor.cs
@@ -1,0 +1,35 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using Umbraco.Core.Logging;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    [DataEditor(
+        DataEditorAlias,
+        EditorType.PropertyValue | EditorType.MacroParameter,
+        DataEditorName,
+        DataEditorViewPath,
+        ValueType = ValueTypes.String,
+        Group = Core.Constants.PropertyEditors.Groups.Pickers,
+#if DEBUG
+        Icon = DataEditorIcon + " color-red"
+#else
+        Icon = DataEditorIcon
+#endif
+        )]
+    public class SocialPickerDataEditor : DataEditor
+    {
+        internal const string DataEditorAlias = Constants.Internals.DataEditorAliasPrefix + "SocialPicker";
+        internal const string DataEditorName = Constants.Internals.DataEditorNamePrefix + "Social Picker";
+        internal const string DataEditorViewPath = Constants.Internals.EditorsPathRoot + "social-picker.html";
+        internal const string DataEditorIcon = "icon-molecular-network";
+
+        public SocialPickerDataEditor(ILogger logger)
+            : base(logger)
+        { }
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/SocialPicker/SocialPickerValueConverter.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/SocialPicker/SocialPickerValueConverter.cs
@@ -1,0 +1,31 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System;
+using Umbraco.Core;
+using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    public class SocialPickerValueConverter : PropertyValueConverterBase
+    {
+        public override bool IsConverter(IPublishedPropertyType propertyType) => propertyType.EditorAlias.InvariantEquals(SocialPickerDataEditor.DataEditorAlias);
+
+        public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Element;
+
+        public override Type GetPropertyValueType(IPublishedPropertyType propertyType) => typeof(string);
+
+        public override object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
+        {
+            if (source is string value)
+            {
+                return value;
+            }
+
+            return base.ConvertSourceToIntermediate(owner, propertyType, source, preview);
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/SocialPicker/social-picker.css
+++ b/src/Umbraco.Community.Contentment/DataEditors/SocialPicker/social-picker.css
@@ -1,0 +1,17 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+.contentment .btn-lk-add {
+    background-color: transparent;
+    border: 1px dashed #d8d7d9;
+    color: #d8d7d9;
+    height: 32px;
+    width: 32px;
+}
+
+    .contentment .btn-lk-add:hover {
+        border-color: #2152a3;
+        color: #2152a3;
+    }

--- a/src/Umbraco.Community.Contentment/DataEditors/SocialPicker/social-picker.html
+++ b/src/Umbraco.Community.Contentment/DataEditors/SocialPicker/social-picker.html
@@ -1,0 +1,10 @@
+﻿<!-- Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+   - This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+<div class="contentment" ng-controller="Umbraco.Community.Contentment.DataEditors.SocialPicker.Controller as vm">
+    <a href="" class="btn btn-social-icon" ng-class="vm.button" ng-click="vm.pick()" prevent-default>
+        <i ng-class="vm.icon"></i>
+    </a>
+</div>

--- a/src/Umbraco.Community.Contentment/DataEditors/SocialPicker/social-picker.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/SocialPicker/social-picker.js
@@ -1,0 +1,68 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.SocialPicker.Controller", [
+    "$scope",
+    "editorService",
+    function ($scope, editorService) {
+
+        //console.log("social-picker.model", $scope.model);
+
+        var defaultConfig = {
+            overlayView: "/App_Plugins/Contentment/editors/social-picker.overlay.html"
+        };
+        var config = angular.extend({}, defaultConfig, $scope.model.config);
+
+        var vm = this;
+
+        function init() {
+
+            $scope.model.value = $scope.model.value || "";
+
+            if ($scope.model.value !== "") {
+                vm.button = "btn-" + $scope.model.value;
+                vm.icon = "fa fa-" + $scope.model.value;
+            }
+            else {
+                vm.button = "btn-lk-add";
+                vm.icon = "icon-add";
+            }
+
+            vm.pick = pick;
+        };
+
+        function pick() {
+            editorService.open({
+                size: "small",
+                view: config.overlayView,
+                value: $scope.model.value,
+                submit: function (model) {
+
+                    $scope.model.value = model.network;
+
+                    vm.button = "btn-" + model.network;
+                    vm.icon = "fa fa-" + (model.icon || model.network);
+
+                    console.log("submit", model, $scope.model.value);
+
+                    setDirty();
+
+                    editorService.close();
+                },
+                close: function () {
+                    editorService.close();
+                }
+            });
+        };
+
+        function setDirty() {
+            if ($scope.propertyForm) {
+                $scope.propertyForm.$setDirty();
+            }
+        };
+
+        init();
+    }
+]);

--- a/src/Umbraco.Community.Contentment/DataEditors/SocialPicker/social-picker.overlay.css
+++ b/src/Umbraco.Community.Contentment/DataEditors/SocialPicker/social-picker.overlay.css
@@ -1,0 +1,9 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+.contentment .lk-social-network {
+    display: inline-block;
+    padding: 0 26px 26px 0;
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/SocialPicker/social-picker.overlay.html
+++ b/src/Umbraco.Community.Contentment/DataEditors/SocialPicker/social-picker.overlay.html
@@ -1,0 +1,49 @@
+﻿<!-- Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+   - This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+<div class="contentment" ng-controller="Umbraco.Community.Contentment.Overlays.SocialPicker.Controller as vm">
+
+    <umb-editor-view>
+
+        <umb-editor-header name="vm.title"
+                           name-locked="true"
+                           hide-alias="true"
+                           hide-icon="true"
+                           hide-description="true">
+        </umb-editor-header>
+
+        <umb-editor-container>
+            <umb-box>
+                <umb-box-content>
+
+                    <div class="lk-social-network" ng-repeat="item in vm.items">
+                        <a class="btn btn-social-icon btn-{{item.network}}"
+                           ng-class="{ active: model.value.network === item.network }"
+                           ng-click="vm.select(item)"
+                           ng-attr-title="{{item.name}}"
+                           prevent-default>
+                            <i class="fa fa-{{item.network}}"></i>
+                        </a>
+                    </div>
+
+                </umb-box-content>
+            </umb-box>
+        </umb-editor-container>
+
+        <umb-editor-footer>
+            <umb-editor-footer-content-right>
+                <umb-button type="button"
+                            button-style="link"
+                            label-key="general_close"
+                            shortcut="esc"
+                            action="vm.close()">
+                </umb-button>
+            </umb-editor-footer-content-right>
+        </umb-editor-footer>
+
+    </umb-editor-view>
+
+</div>
+

--- a/src/Umbraco.Community.Contentment/DataEditors/SocialPicker/social-picker.overlay.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/SocialPicker/social-picker.overlay.js
@@ -1,0 +1,60 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+angular.module("umbraco").controller("Umbraco.Community.Contentment.Overlays.SocialPicker.Controller", [
+    "$scope",
+    "editorService",
+    function ($scope, editorService) {
+
+        // console.log("social-picker-overlay.model", $scope.model);
+
+        var defaultConfig = {
+            title: "Select social network...",
+        };
+        var config = angular.extend({}, defaultConfig, $scope.model.config);
+
+        var vm = this;
+
+        function init() {
+
+            vm.title = config.title;
+
+            // NOTE: I've deliberately not added: adn, dropbox, foursquare, google, microsoft, openid
+            vm.items = [
+                { name: "Bitbucket", network: "bitbucket", url: "https://bitbucket.org/" },
+                { name: "Facebook", network: "facebook", url: "https://facebook.com/" },
+                { name: "Flickr", network: "flickr", url: "https://www.flickr.com/" },
+                { name: "GitHub", network: "github", url: "https://github.com/" },
+                { name: "Instagram", network: "instagram", url: "https://instagram.com/" },
+                { name: "LinkedIn", network: "linkedin", url: "https://linkedin.com/in/" },
+                { name: "Одноклассники", network: "odnoklassniki", url: "https://ok.ru/" },
+                { name: "Pinterest", network: "pinterest", url: "https://pinterest.com/" },
+                { name: "Reddit", network: "reddit", url: "https://www.reddit.com/user/" },
+                { name: "SoundCloud", network: "soundcloud", url: "https://soundcloud.com/" },
+                { name: "Tumblr", network: "tumblr", url: "https://{username}.tumblr.com/" },
+                { name: "Twitter", network: "twitter", url: "https://twitter.com/" },
+                { name: "Vimeo", network: "vimeo", url: "https://vimeo.com/" },
+                { name: "VK", network: "vk", url: "https://vk.com/" },
+            ];
+
+            vm.select = select;
+            vm.close = close;
+        };
+
+        function select(item) {
+            if ($scope.model.submit) {
+                $scope.model.submit(item);
+            }
+        };
+
+        function close() {
+            if ($scope.model.close) {
+                $scope.model.close();
+            }
+        };
+
+        init();
+    }
+]);

--- a/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
+++ b/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
@@ -291,6 +291,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Configuration\ContentmentVersion.cs" />
+    <Compile Include="DataEditors\DataList\DataSources\FontAwesomeDataSource.cs" />
     <Compile Include="DataEditors\TextInput\TextInputDataListEditor.cs" />
     <Compile Include="Experience\HidePropertyLabelComponent.cs" />
     <Compile Include="Experience\MarkdownPropertyDescriptionComponent.cs" />
@@ -300,6 +301,12 @@
     <Compile Include="Constants.cs" />
     <Compile Include="DataEditors\TextInput\TextInputConfigurationEditor.cs" />
     <Compile Include="DataEditors\TextInput\TextInputDataEditor.cs" />
+    <Compile Include="DataEditors\DataList\DataSources\TimeZoneDataSource.cs" />
+    <Compile Include="DataEditors\SocialLinks\SocialLinksDataEditor.cs" />
+    <Compile Include="DataEditors\SocialLinks\SocialLinksValueConverter.cs" />
+    <Compile Include="DataEditors\SocialLinks\SocialLink.cs" />
+    <Compile Include="DataEditors\SocialPicker\SocialPickerValueConverter.cs" />
+    <Compile Include="DataEditors\SocialPicker\SocialPickerDataEditor.cs" />
     <Compile Include="DataEditors\Bytes\BytesConfigurationEditor.cs" />
     <Compile Include="DataEditors\Bytes\BytesDataEditor.cs" />
     <Compile Include="DataEditors\Bytes\BytesValueConverter.cs" />
@@ -337,12 +344,10 @@
     <Compile Include="DataEditors\DataList\DataListItemAttribute.cs" />
     <Compile Include="DataEditors\DataList\DataListValueConverter.cs" />
     <Compile Include="DataEditors\DataList\DataSources\EnumDataListSource.cs" />
-    <Compile Include="DataEditors\DataList\DataSources\FontAwesomeDataSource.cs" />
     <Compile Include="DataEditors\DataList\DataSources\IDataListSource.cs" />
     <Compile Include="DataEditors\DataList\DataSources\UserDefinedDataListSource.cs" />
     <Compile Include="DataEditors\DataList\DataSources\PhysicalFileSystemDataSource.cs" />
     <Compile Include="DataEditors\DataList\DataSources\SqlDataListSource.cs" />
-    <Compile Include="DataEditors\DataList\DataSources\TimeZoneDataSource.cs" />
     <Compile Include="DataEditors\DataList\DataSources\UmbracoEntityDataListSource.cs" />
     <Compile Include="DataEditors\DataList\DataSources\XmlDataListSource.cs" />
     <Compile Include="DataEditors\DataList\IDataListEditor.cs" />
@@ -436,6 +441,15 @@
     <Content Include="DataEditors\ConfigurationEditor\configuration-editor.overlay.html" />
     <Content Include="DataEditors\ConfigurationEditor\configuration-editor.overlay.js" />
     <Content Include="DataEditors\DataTable\data-table.html" />
+    <Content Include="DataEditors\SocialLinks\social-links.css" />
+    <Content Include="DataEditors\SocialLinks\social-links.html" />
+    <Content Include="DataEditors\SocialLinks\social-links.js" />
+    <Content Include="DataEditors\SocialPicker\social-picker.overlay.css" />
+    <Content Include="DataEditors\SocialPicker\social-picker.overlay.js" />
+    <Content Include="DataEditors\SocialPicker\social-picker.overlay.html" />
+    <Content Include="DataEditors\SocialPicker\social-picker.css" />
+    <Content Include="DataEditors\SocialPicker\social-picker.html" />
+    <Content Include="DataEditors\SocialPicker\social-picker.js" />
     <Content Include="DataEditors\DataTable\data-table.js" />
     <Content Include="DataEditors\DropdownList\dropdown-list.html" />
     <Content Include="DataEditors\DropdownList\dropdown-list.js" />


### PR DESCRIPTION
Adds 2 editors - "Social Links" and "Social Picker".

Lets you pick from a selection of social network icons, then provides two textboxes to enter the label and URL of the links.

Utilises the "bootstrap-social.css" (that ships with Umbraco out-the-box).

![social-links-01](https://user-images.githubusercontent.com/209066/69537427-fdb14700-0f77-11ea-90c4-c85ada156c86.png)

![social-links-02](https://user-images.githubusercontent.com/209066/69537428-fdb14700-0f77-11ea-98c6-08af24b2e5c4.png)
