### PR TITLE
Auto-registering Umbraco package entry

### DIFF
--- a/src/Umbraco.Community.Contentment/Composing/ContentmentComponent.cs
+++ b/src/Umbraco.Community.Contentment/Composing/ContentmentComponent.cs
@@ -1,0 +1,44 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using Umbraco.Community.Contentment.Migrations;
+using Umbraco.Core.Composing;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Migrations;
+using Umbraco.Core.Migrations.Upgrade;
+using Umbraco.Core.Scoping;
+using Umbraco.Core.Services;
+
+namespace Umbraco.Community.Contentment.Composing
+{
+    internal class ContentmentComponent : IComponent
+    {
+        private readonly IScopeProvider _scopeProvider;
+        private readonly IMigrationBuilder _migrationBuilder;
+        private readonly IKeyValueService _keyValueService;
+        private readonly IProfilingLogger _logger;
+
+        public ContentmentComponent(
+            IScopeProvider scopeProvider,
+            IMigrationBuilder migrationBuilder,
+            IKeyValueService keyValueService,
+            IProfilingLogger logger)
+        {
+            this._scopeProvider = scopeProvider;
+            this._migrationBuilder = migrationBuilder;
+            this._keyValueService = keyValueService;
+            this._logger = logger;
+        }
+
+        public void Initialize()
+        {
+            var upgrader = new Upgrader(new ContentmentPlan());
+            upgrader.Execute(_scopeProvider, _migrationBuilder, _keyValueService, _logger);
+        }
+
+        public void Terminate()
+        { }
+    }
+}

--- a/src/Umbraco.Community.Contentment/Composing/ContentmentComposer.cs
+++ b/src/Umbraco.Community.Contentment/Composing/ContentmentComposer.cs
@@ -1,18 +1,19 @@
 ﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
-* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 using Umbraco.Core;
 using Umbraco.Core.Composing;
 
-namespace Umbraco.Community.Contentment
+namespace Umbraco.Community.Contentment.Composing
 {
     [RuntimeLevel(MinLevel = RuntimeLevel.Run)]
-    public class ContentmentComposer : IUserComposer
+    internal class ContentmentComposer : IUserComposer
     {
         public void Compose(Composition composition)
         {
+            composition.Components().Append<ContentmentComponent>();
         }
     }
 }

--- a/src/Umbraco.Community.Contentment/Constants.cs
+++ b/src/Umbraco.Community.Contentment/Constants.cs
@@ -44,6 +44,25 @@ namespace Umbraco.Community.Contentment
             }
         }
 
+        internal static partial class Package
+        {
+            internal const string Author = "Lee Kelleher";
+
+            internal const string AuthorUrl = "https://leekelleher.com";
+
+            internal static readonly System.Version ContentmentVersion = new System.Version(1, 0, 0);
+
+            internal const string IconUrl = "https://raw.githubusercontent.com/leekelleher/umbraco-contentment/master/docs/assets/img/logo.png";
+
+            internal const string License = "Mozilla Public License";
+
+            internal const string LicenseUrl = "https://mozilla.org/MPL/2.0/";
+
+            internal static readonly System.Version MinimumSupportedUmbracoVersion = new System.Version(8, 1, 0);
+
+            internal const string RepositoryUrl = "https://github.com/leekelleher/umbraco-contentment";
+        }
+
         internal static partial class Values
         {
             public const string True = "1";

--- a/src/Umbraco.Community.Contentment/Migrations/ContentmentPlan.cs
+++ b/src/Umbraco.Community.Contentment/Migrations/ContentmentPlan.cs
@@ -1,0 +1,21 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using Umbraco.Community.Contentment.Migrations.Install;
+using Umbraco.Core.Migrations;
+
+namespace Umbraco.Community.Contentment.Migrations
+{
+    internal class ContentmentPlan : MigrationPlan
+    {
+        public ContentmentPlan()
+            : base(Constants.Internals.ProjectName)
+        {
+            From(string.Empty)
+                .To<RegisterUmbracoPackageEntry>("{92FFD63F-44DC-4555-A347-87C5B1D24D6E}")
+            ;
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/Migrations/Install/RegisterUmbracoPackageEntry.cs
+++ b/src/Umbraco.Community.Contentment/Migrations/Install/RegisterUmbracoPackageEntry.cs
@@ -1,0 +1,48 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System;
+using System.Linq;
+using Umbraco.Core.IO;
+using Umbraco.Core.Migrations;
+using Umbraco.Core.Models.Packaging;
+using Umbraco.Core.Services;
+
+namespace Umbraco.Community.Contentment.Migrations.Install
+{
+    internal class RegisterUmbracoPackageEntry : MigrationBase
+    {
+        private readonly IPackagingService _packagingService;
+
+        public RegisterUmbracoPackageEntry(IPackagingService packagingService, IMigrationContext context)
+            : base(context)
+        {
+            _packagingService = packagingService;
+        }
+
+        public override void Migrate()
+        {
+            // Check if the package has already been installed.
+            var pkgs = _packagingService.GetInstalledPackageByName(Constants.Internals.ProjectName);
+            if (pkgs?.Any() == false)
+            {
+                // If not, then make a package definition and save it to the "installedPackages.config".
+                _packagingService.SaveInstalledPackage(new PackageDefinition
+                {
+                    Name = Constants.Internals.ProjectName,
+                    Url = Constants.Package.RepositoryUrl,
+                    Author = Constants.Package.Author,
+                    AuthorUrl = Constants.Package.AuthorUrl,
+                    IconUrl = Constants.Package.IconUrl,
+                    License = Constants.Package.License,
+                    LicenseUrl = Constants.Package.LicenseUrl,
+                    UmbracoVersion = Constants.Package.MinimumSupportedUmbracoVersion,
+                    Version = Constants.Package.ContentmentVersion.ToString(),
+                    Readme = "",
+                });
+            }
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
+++ b/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
@@ -290,7 +290,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Composing\ContentmentComponent.cs" />
     <Compile Include="Composing\ContentmentComposer.cs" />
+    <Compile Include="Migrations\Install\RegisterUmbracoPackageEntry.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="DataEditors\Bytes\BytesConfigurationEditor.cs" />
     <Compile Include="DataEditors\Bytes\BytesDataEditor.cs" />
@@ -393,6 +395,7 @@
     <Compile Include="DataEditors\_\OrientationConfigurationField.cs" />
     <Compile Include="DataEditors\_\ReadOnlyDataValueEditor.cs" />
     <Compile Include="DataEditors\_\ShowDescriptionsConfigurationField.cs" />
+    <Compile Include="Migrations\ContentmentPlan.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Trees\ContentmentTreeController.cs" />
     <Compile Include="Web\Controllers\EnumDataListSourceApiController.cs" />


### PR DESCRIPTION
Adds Umbraco migration code (on installation) to manually add the Contentment package to the "installed packages" in the Umbraco back-office.

The scenario behind this is if you install via NuGet. Then the back-office has no idea that the package is installed.

By having it recognised as "installed", is that it could be uninstalled and the "options" page could (potentially) be set too.

