### PR TITLE
Excluded unsupported DataEditors

### DIFF
--- a/src/Umbraco.Community.Contentment/Composing/ContentmentComposer.cs
+++ b/src/Umbraco.Community.Contentment/Composing/ContentmentComposer.cs
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+using Umbraco.Community.Contentment.DataEditors;
 using Umbraco.Core;
 using Umbraco.Core.Composing;
 
@@ -14,6 +15,24 @@ namespace Umbraco.Community.Contentment.Composing
         public void Compose(Composition composition)
         {
             composition.Components().Append<ContentmentComponent>();
+#if !DEBUG
+            composition
+                .DataEditors()
+                    .Exclude<CardsDataEditor>()
+                    .Exclude<CascadingDropdownListDataEditor>()
+                    .Exclude<CheckboxDataEditor>()
+                    .Exclude<CheckboxListDataEditor>()
+                    .Exclude<CodeEditorDataEditor>()
+                    .Exclude<ConfigurationEditorDataEditor>()
+                    .Exclude<DataTableDataEditor>()
+                    .Exclude<DropdownListDataEditor>()
+                    .Exclude<ElementDataEditor>()
+                    .Exclude<ItemPickerDataEditor>()
+                    .Exclude<MacroPickerDataEditor>()
+                    .Exclude<RadioButtonListDataEditor>()
+                    .Exclude<TogglesDataEditor>()
+            ;
+#endif
         }
     }
 }

--- a/src/Umbraco.Community.Contentment/DataEditors/Cards/CardsDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/Cards/CardsDataEditor.cs
@@ -10,11 +10,7 @@ namespace Umbraco.Community.Contentment.DataEditors
 {
     [DataEditor(
         DataEditorAlias,
-#if DEBUG
-        EditorType.PropertyValue, // NOTE: IsWorkInProgress [LK]
-#else
-        EditorType.Nothing,
-#endif
+        EditorType.PropertyValue,
         DataEditorName,
         DataEditorViewPath,
         ValueType = ValueTypes.Json,

--- a/src/Umbraco.Community.Contentment/DataEditors/CascadingDropdownList/CascadingDropdownListDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/CascadingDropdownList/CascadingDropdownListDataEditor.cs
@@ -10,11 +10,7 @@ namespace Umbraco.Community.Contentment.DataEditors
 {
     [DataEditor(
         DataEditorAlias,
-#if DEBUG
-        EditorType.PropertyValue, // NOTE: IsWorkInProgress [LK]
-#else
-        EditorType.Nothing,
-#endif
+        EditorType.PropertyValue,
         DataEditorName,
         DataEditorViewPath,
         ValueType = ValueTypes.Json,

--- a/src/Umbraco.Community.Contentment/DataEditors/Checkbox/CheckboxDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/Checkbox/CheckboxDataEditor.cs
@@ -10,11 +10,7 @@ namespace Umbraco.Community.Contentment.DataEditors
 {
     [DataEditor(
         DataEditorAlias,
-#if DEBUG
-        EditorType.PropertyValue, // NOTE: IsWorkInProgress [LK]
-#else
-        EditorType.Nothing,
-#endif
+        EditorType.PropertyValue,
         DataEditorName,
         DataEditorViewPath,
         ValueType = ValueTypes.Integer,

--- a/src/Umbraco.Community.Contentment/DataEditors/CheckboxList/CheckboxListDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/CheckboxList/CheckboxListDataEditor.cs
@@ -10,11 +10,7 @@ namespace Umbraco.Community.Contentment.DataEditors
 {
     [DataEditor(
         DataEditorAlias,
-#if DEBUG
-        EditorType.PropertyValue, // NOTE: IsWorkInProgress [LK]
-#else
-        EditorType.Nothing,
-#endif
+        EditorType.PropertyValue,
         DataEditorName,
         DataEditorViewPath,
         ValueType = ValueTypes.Json,

--- a/src/Umbraco.Community.Contentment/DataEditors/CodeEditor/CodeEditorDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/CodeEditor/CodeEditorDataEditor.cs
@@ -10,11 +10,7 @@ namespace Umbraco.Community.Contentment.DataEditors
 {
     [DataEditor(
         DataEditorAlias,
-#if DEBUG
-        EditorType.PropertyValue, // NOTE: IsWorkInProgress [LK]
-#else
-        EditorType.Nothing,
-#endif
+        EditorType.PropertyValue,
         DataEditorName,
         DataEditorViewPath,
         ValueType = ValueTypes.Text,

--- a/src/Umbraco.Community.Contentment/DataEditors/ConfigurationEditor/ConfigurationEditorDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/ConfigurationEditor/ConfigurationEditorDataEditor.cs
@@ -10,11 +10,7 @@ namespace Umbraco.Community.Contentment.DataEditors
 {
     [DataEditor(
         DataEditorAlias,
-#if DEBUG
-        EditorType.PropertyValue, // NOTE: IsWorkInProgress [LK]
-#else
-        EditorType.Nothing,
-#endif
+        EditorType.PropertyValue,
         DataEditorName,
         DataEditorViewPath,
         ValueType = ValueTypes.Json,

--- a/src/Umbraco.Community.Contentment/DataEditors/DataTable/DataTableDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataTable/DataTableDataEditor.cs
@@ -10,11 +10,7 @@ namespace Umbraco.Community.Contentment.DataEditors
 {
     [DataEditor(
         DataEditorAlias,
-#if DEBUG
-        EditorType.PropertyValue, // NOTE: IsWorkInProgress [LK]
-#else
-        EditorType.Nothing,
-#endif
+        EditorType.PropertyValue,
         DataEditorName,
         DataEditorViewPath,
         ValueType = ValueTypes.Json,

--- a/src/Umbraco.Community.Contentment/DataEditors/DropdownList/DropdownListDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DropdownList/DropdownListDataEditor.cs
@@ -10,11 +10,7 @@ namespace Umbraco.Community.Contentment.DataEditors
 {
     [DataEditor(
         DataEditorAlias,
-#if DEBUG
-        EditorType.PropertyValue, // NOTE: IsWorkInProgress [LK]
-#else
-        EditorType.Nothing,
-#endif
+        EditorType.PropertyValue,
         DataEditorName,
         DataEditorViewPath,
         ValueType = ValueTypes.String,

--- a/src/Umbraco.Community.Contentment/DataEditors/Element/ElementDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/Element/ElementDataEditor.cs
@@ -11,11 +11,7 @@ namespace Umbraco.Community.Contentment.DataEditors
 {
     [DataEditor(
         DataEditorAlias,
-#if DEBUG
-        EditorType.PropertyValue, // NOTE: IsWorkInProgress [LK]
-#else
-        EditorType.Nothing,
-#endif
+        EditorType.PropertyValue,
         DataEditorName,
         DataEditorViewPath,
         ValueType = ValueTypes.Json,

--- a/src/Umbraco.Community.Contentment/DataEditors/ItemPicker/ItemPickerDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/ItemPicker/ItemPickerDataEditor.cs
@@ -10,11 +10,7 @@ namespace Umbraco.Community.Contentment.DataEditors
 {
     [DataEditor(
         DataEditorAlias,
-#if DEBUG
-        EditorType.PropertyValue, // NOTE: IsWorkInProgress [LK]
-#else
-        EditorType.Nothing,
-#endif
+        EditorType.PropertyValue,
         DataEditorName,
         DataEditorViewPath,
         ValueType = ValueTypes.Json,

--- a/src/Umbraco.Community.Contentment/DataEditors/MacroPicker/MacroPickerDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/MacroPicker/MacroPickerDataEditor.cs
@@ -11,11 +11,7 @@ namespace Umbraco.Community.Contentment.DataEditors
 {
     [DataEditor(
         DataEditorAlias,
-#if DEBUG
-        EditorType.PropertyValue | EditorType.MacroParameter, // NOTE: IsWorkInProgress [LK]
-#else
-        EditorType.Nothing,
-#endif
+        EditorType.PropertyValue | EditorType.MacroParameter,
         DataEditorName,
         DataEditorViewPath,
         ValueType = ValueTypes.Json,

--- a/src/Umbraco.Community.Contentment/DataEditors/RadioButtonList/RadioButtonListDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/RadioButtonList/RadioButtonListDataEditor.cs
@@ -10,11 +10,7 @@ namespace Umbraco.Community.Contentment.DataEditors
 {
     [DataEditor(
         DataEditorAlias,
-#if DEBUG
-        EditorType.PropertyValue, // NOTE: IsWorkInProgress [LK]
-#else
-        EditorType.Nothing,
-#endif
+        EditorType.PropertyValue,
         DataEditorName,
         DataEditorViewPath,
         ValueType = ValueTypes.String,

--- a/src/Umbraco.Community.Contentment/DataEditors/Toggles/TogglesDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/Toggles/TogglesDataEditor.cs
@@ -10,11 +10,7 @@ namespace Umbraco.Community.Contentment.DataEditors
 {
     [DataEditor(
         DataEditorAlias,
-#if DEBUG
-        EditorType.PropertyValue, // NOTE: IsWorkInProgress [LK]
-#else
-        EditorType.Nothing,
-#endif
+        EditorType.PropertyValue,
         DataEditorName,
         DataEditorViewPath,
         ValueType = ValueTypes.Json,


### PR DESCRIPTION
There are bunch of internal data-editors that are currently used to support the main property-editors. I don't consider these internal data-editors to be fully fleshed out property-editors for public consumption.

In time they could be, but for now, I'd prefer to exclude them from a public release.

_Note: Although they will still be available when compiled in **Debug** mode, they will be unsupported._ 