### PR TITLE
Adds "Text Input" editor

### DIFF
--- a/.github/IDEAS.md
+++ b/.github/IDEAS.md
@@ -11,8 +11,6 @@
   Enable editing of a local file's content, e.g. robots.txt
   Something similar to this, https://our.umbraco.com/packages/website-utilities/umbraco-content-files/, but not as tied to the doctype.
 
-- Smaller number input (+ label suffix)
-  https://github.com/umbraco/Umbraco-CMS/blob/release-8.1.0/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html#L36-L40
 
 - Template editor (type of thing?) Add columns (blocks). Each one could be an InnerContent-esque editor?
   https://github.com/umbraco/Umbraco-CMS/blob/release-8.1.0/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.html#L44-L64

--- a/src/Umbraco.Community.Contentment/AjaxMin.xml
+++ b/src/Umbraco.Community.Contentment/AjaxMin.xml
@@ -25,6 +25,7 @@
         <input path="DataEditors\MacroPicker\macro-picker.js" />
         <input path="DataEditors\RadioButtonList\radio-button-list.js" />
         <input path="DataEditors\RenderMacro\render-macro.js" />
+        <input path="DataEditors\TextInput\text-input.js" />
         <input path="DataEditors\Toggles\toggles.js" />
         <input path="DataEditors\_\_dev-mode.js" />
     </output>
@@ -36,5 +37,6 @@
         <input path="DataEditors\IconPicker\icon-picker.css" />
         <input path="DataEditors\ItemPicker\item-picker.overlay.css" />
         <input path="DataEditors\RadioButtonList\radio-button-list.css" />
+        <input path="DataEditors\TextInput\text-input.css" />
     </output>
 </root>

--- a/src/Umbraco.Community.Contentment/Composing/ContentmentComposer.cs
+++ b/src/Umbraco.Community.Contentment/Composing/ContentmentComposer.cs
@@ -33,6 +33,7 @@ namespace Umbraco.Community.Contentment.Composing
                     .Exclude<ItemPickerDataEditor>()
                     .Exclude<MacroPickerDataEditor>()
                     .Exclude<RadioButtonListDataEditor>()
+                    .Exclude<TextInputDataEditor>()
                     .Exclude<TogglesDataEditor>()
 #endif
             ;

--- a/src/Umbraco.Community.Contentment/DataEditors/TextInput/TextInputConfigurationEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/TextInput/TextInputConfigurationEditor.cs
@@ -1,0 +1,113 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Umbraco.Core.Composing;
+using Umbraco.Core.IO;
+using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.Serialization;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    internal sealed class TextInputConfigurationEditor : ConfigurationEditor
+    {
+        public const string Autocomplete = "autocomplete";
+        public const string Items = "items";
+        public const string MaxChars = "maxChars";
+        public const string PlaceholderText = "placeholderText";
+
+        public TextInputConfigurationEditor()
+            : base()
+        {
+            Fields.Add(
+                PlaceholderText,
+                "Placeholder text",
+                "Add placeholder text for the text input. This is to be used as instructional information, not as a default value.",
+                "textstring");
+
+            Fields.Add(
+                "autocomplete",
+                "Enable autocomplete?",
+                "Select to enable autocomplete functionality on the text input.",
+                "boolean");
+
+            Fields.Add(
+                "maxChars",
+                "Maximum allowed characters",
+                "Enter the maximum number of characters allowed for the text input.<br>The default is a 500 character limit.",
+                "number");
+
+            //Fields.Add(
+            //    "prepend",
+            //    "Prepend Icon",
+            //    "[Add friendly description]",
+            //    IOHelper.ResolveUrl(IconPickerDataEditor.DataEditorViewPath),
+            //    new Dictionary<string, object>
+            //    {
+            //        { DefaultIconConfigurationField.DefaultIcon, string.Empty },
+            //        { IconPickerSizeConfigurationField.Size, IconPickerSizeConfigurationField.Large }
+            //    });
+
+            //Fields.Add(
+            //    "append",
+            //    "Append Icon",
+            //    "[Add friendly description]",
+            //    IOHelper.ResolveUrl(IconPickerDataEditor.DataEditorViewPath),
+            //    new Dictionary<string, object>
+            //    {
+            //        { DefaultIconConfigurationField.DefaultIcon, string.Empty },
+            //        { IconPickerSizeConfigurationField.Size, IconPickerSizeConfigurationField.Large }
+            //    });
+
+            var service = new ConfigurationEditorService();
+            var dataSources = service.GetConfigurationEditors<IDataListSource>();
+
+            Fields.Add(
+                Items,
+                "Data list",
+                "<em>(optional)</em> Select and configure the data source to provide a HTML5 &lt;datalist&gt; for this text input.",
+                IOHelper.ResolveUrl(ConfigurationEditorDataEditor.DataEditorViewPath),
+                new Dictionary<string, object>()
+                {
+                    { OverlaySizeConfigurationField.OverlaySize, OverlaySizeConfigurationField.Small },
+                    { ConfigurationEditorConfigurationEditor.OverlayView, IOHelper.ResolveUrl(ConfigurationEditorDataEditor.DataEditorOverlayViewPath) },
+                    { ConfigurationEditorConfigurationEditor.Items, dataSources },
+                    { EnableDevModeConfigurationField.EnableDevMode, Constants.Values.False },
+                    { DisableSortingConfigurationField.DisableSorting, Constants.Values.True },
+                    { MaxItemsConfigurationField.MaxItems, 1 },
+                });
+        }
+
+        public override IDictionary<string, object> ToValueEditor(object configuration)
+        {
+            var config = base.ToValueEditor(configuration);
+
+            if (config.TryGetValue(Items, out var items) && items is JArray array && array.Count > 0)
+            {
+                var item = array[0];
+
+                var type = TypeFinder.GetTypeByName(item.Value<string>("type"));
+                if (type != null)
+                {
+                    var serializer = JsonSerializer.CreateDefault(new JsonSerializerSettings
+                    {
+                        ContractResolver = new ConfigurationFieldContractResolver(),
+                        Converters = new List<JsonConverter>(new[] { new FuzzyBooleanConverter() })
+                    });
+
+                    var source = item["value"].ToObject(type, serializer) as IDataListSource;
+                    var options = source?.GetItems() ?? Enumerable.Empty<DataListItem>();
+
+                    config[Items] = options;
+                }
+            }
+
+            return config;
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/TextInput/TextInputDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/TextInput/TextInputDataEditor.cs
@@ -1,0 +1,37 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using Umbraco.Core.Logging;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    [DataEditor(
+        DataEditorAlias,
+        EditorType.PropertyValue,
+        DataEditorName,
+        DataEditorViewPath,
+        ValueType = ValueTypes.String,
+        Group = Core.Constants.PropertyEditors.Groups.Common,
+#if DEBUG
+        Icon = "icon-block color-red"
+#else
+        Icon = DataEditorIcon
+#endif
+        )]
+    internal sealed class TextInputDataEditor : DataEditor
+    {
+        internal const string DataEditorAlias = Constants.Internals.DataEditorAliasPrefix + "TextInput";
+        internal const string DataEditorName = Constants.Internals.DataEditorNamePrefix + "Text Input";
+        internal const string DataEditorViewPath = Constants.Internals.EditorsPathRoot + "text-input.html";
+        internal const string DataEditorIcon = "icon-autofill";
+
+        public TextInputDataEditor(ILogger logger)
+            : base(logger)
+        { }
+
+        protected override IConfigurationEditor CreateConfigurationEditor() => new TextInputConfigurationEditor();
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/TextInput/TextInputDataListEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/TextInput/TextInputDataListEditor.cs
@@ -1,0 +1,35 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System.Collections.Generic;
+using Umbraco.Core.Composing;
+using Umbraco.Core.IO;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    [HideFromTypeFinder]
+    internal sealed class TextInputDataListEditor : IDataListEditor
+    {
+        public string Name => "Text Input";
+
+        public string Description => "A textbox input, with optional values from a data-list.";
+
+        public string Icon => TextInputDataEditor.DataEditorIcon;
+
+        public Dictionary<string, object> DefaultConfig => default;
+
+        public string View => IOHelper.ResolveUrl(TextInputDataEditor.DataEditorViewPath);
+
+        [ConfigurationField("placeholderText", "Placeholder text", "textstring", Description = "Add placeholder text for the text input.<br>This is to be used as instructional information, not as a default value.")]
+        public string PlaceholderText { get; set; }
+
+        [ConfigurationField("autocomplete", "Enable autocomplete?", "boolean", Description = "Select to enable autocomplete functionality on the text input.")]
+        public bool Autocomplete { get; set; }
+
+        [ConfigurationField("maxChars", "Maximum allowed characters", "number", Description = "Enter the maximum number of characters allowed for the text input.<br>The default is a 500 character limit.")]
+        public int MaxChars { get; set; }
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/TextInput/text-input.css
+++ b/src/Umbraco.Community.Contentment/DataEditors/TextInput/text-input.css
@@ -1,0 +1,17 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+.contentment .text-input {
+    width: 800px;
+}
+
+    .contentment .text-input.input-prepend .umb-textstring,
+    .contentment .text-input.input-append .umb-textstring {
+        width: 768px;
+    }
+
+    .contentment .text-input.input-prepend.input-append .umb-textstring {
+        width: 740px;
+    }

--- a/src/Umbraco.Community.Contentment/DataEditors/TextInput/text-input.html
+++ b/src/Umbraco.Community.Contentment/DataEditors/TextInput/text-input.html
@@ -1,0 +1,46 @@
+﻿<!-- Copyright © 2013-present Umbraco.
+   - Parts of this Source Code has been derived from Umbraco CMS.
+   - https://github.com/umbraco/Umbraco-CMS/blob/release-8.2.0-rc/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textbox/textbox.html
+   - Modified under the permissions of the MIT License.
+   - Modifications are licensed under the Mozilla Public License.
+   - Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+   - This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+<div class="contentment" ng-controller="Umbraco.Community.Contentment.DataEditors.TextInput.Controller as vm">
+    <div class="text-input" ng-class="{ 'input-prepend': vm.prepend, 'input-append': vm.append }">
+        <span class="add-on" ng-if="vm.prepend">
+            <i class="icon" ng-class="vm.prepend"></i>
+        </span>
+        <input ng-model="model.value"
+               ng-trim="false"
+               id="{{model.alias}}"
+               name="textbox"
+               class="umb-property-editor umb-textstring"
+               type="text"
+               list="{{vm.dataListId}}"
+               autocomplete="{{vm.autoComplete}}"
+               placeholder="{{vm.placeholderText}}" />
+        <span class="add-on" ng-if="vm.append">
+            <i class="icon" ng-class="vm.append"></i>
+        </span>
+    </div>
+    <div class="help" ng-if="model.value.length >= vm.maxCharsThreshold && model.value.length <= vm.maxChars">
+        <p tabindex="0">
+            <span class="sr-only">{{model.label}}</span>
+            <localize key="textbox_characters_left" tokens="[vm.maxChars - model.value.length]" watch-tokens="true">%0% characters left.</localize>
+        </p>
+    </div>
+    <div class="help text-error" ng-if="model.value.length > vm.maxChars">
+        <p tabindex="0">
+            <span class="sr-only">{{model.label}}</span>
+            <localize key="textbox_characters_exceed" tokens="[vm.maxChars, model.value.length - vm.maxChars]" watch-tokens="true">Maximum %0% characters, <strong>%1%</strong> too many.</localize>
+        </p>
+    </div>
+    <datalist id="{{vm.dataListId}}" ng-if="vm.dataList">
+        <option ng-repeat="item in vm.dataList"
+                label="{{item.name}}"
+                value="{{item.value}}"></option>
+    </datalist>
+</div>

--- a/src/Umbraco.Community.Contentment/DataEditors/TextInput/text-input.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/TextInput/text-input.js
@@ -1,0 +1,49 @@
+﻿/* Copyright © 2019 Lee Kelleher, Umbrella Inc and other contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.TextInput.Controller", [
+    "$scope",
+    function ($scope) {
+
+        // console.log("text-input.model", $scope.model);
+
+        var defaultConfig = {
+            items: [],
+            autocomplete: 0,
+            placeholderText: null,
+            defaultValue: null,
+            prepend: null,
+            append: null,
+            maxChars: 500
+        };
+        var config = angular.extend({}, defaultConfig, $scope.model.config);
+
+        var vm = this;
+
+        function init() {
+
+            $scope.model.value = $scope.model.value || config.defaultValue;
+
+            if (_.isArray($scope.model.value)) {
+                $scope.model.value = $scope.model.value.join(", ");
+            }
+
+            vm.autoComplete = Object.toBoolean(config.autocomplete) ? "on" : "off";
+            vm.placeholderText = config.placeholderText;
+            vm.maxChars = parseInt(0 + config.maxChars);
+            vm.maxCharsThreshold = vm.maxChars * .8;
+
+            vm.prepend = config.prepend;
+            vm.append = config.append;
+
+            if (config.items && config.items.length > 0) {
+                vm.dataListId = $scope.model.alias + $scope.model.dataTypeKey.substring(0, 8);
+                vm.dataList = config.items;
+            }
+        };
+
+        init();
+    }
+]);

--- a/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
+++ b/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
@@ -290,12 +290,15 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DataEditors\TextInput\TextInputDataListEditor.cs" />
     <Compile Include="Experience\HidePropertyLabelComponent.cs" />
     <Compile Include="Experience\MarkdownPropertyDescriptionComponent.cs" />
     <Compile Include="Composing\ContentmentComponent.cs" />
     <Compile Include="Composing\ContentmentComposer.cs" />
     <Compile Include="Migrations\Install\RegisterUmbracoPackageEntry.cs" />
     <Compile Include="Constants.cs" />
+    <Compile Include="DataEditors\TextInput\TextInputConfigurationEditor.cs" />
+    <Compile Include="DataEditors\TextInput\TextInputDataEditor.cs" />
     <Compile Include="DataEditors\Bytes\BytesConfigurationEditor.cs" />
     <Compile Include="DataEditors\Bytes\BytesDataEditor.cs" />
     <Compile Include="DataEditors\Bytes\BytesValueConverter.cs" />
@@ -437,6 +440,9 @@
     <Content Include="DataEditors\Element\element.html" />
     <Content Include="DataEditors\Element\element.js" />
     <Content Include="DataEditors\Element\element.overlay.html" />
+    <Content Include="DataEditors\TextInput\text-input.css" />
+    <Content Include="DataEditors\TextInput\text-input.html" />
+    <Content Include="DataEditors\TextInput\text-input.js" />
     <Content Include="DataEditors\Element\element.overlay.js" />
     <Content Include="DataEditors\IconPicker\icon-picker.css" />
     <Content Include="DataEditors\IconPicker\icon-picker.html" />


### PR DESCRIPTION
### Description

Adds a "Text Input" editor.

This is similar to Umbraco's "textbox" property-editor, with the addition of `placeholder` and `autocomplete` attributes, and `data-list` feature, (which can be populated by a Data List's Data Source.

### Types of changes

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [x] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
