### PR TITLE
Data Type "Copy" feature

### DIFF
--- a/build/build-assets.ps1
+++ b/build/build-assets.ps1
@@ -34,7 +34,7 @@ $pluginFolder = "${targetFolder}\App_Plugins\Contentment\";
 if (!(Test-Path -Path $pluginFolder)) {New-Item -Path $pluginFolder -Type Directory;}
 Copy-Item -Path "${ProjectDir}Web\UI\App_Plugins\Contentment\*" -Force -Recurse -Destination "${pluginFolder}";
 
-# HTML - Copy and Minify (or just remove comments)
+# HTML (Property Editors) - Copy and Minify (or just remove comments)
 $htmlFiles = Get-ChildItem -Path "${ProjectDir}DataEditors" -Recurse -Force -Include *.html;
 foreach($htmlFile in $htmlFiles){
     $contents = Get-Content -Path $htmlFile.FullName;
@@ -42,14 +42,22 @@ foreach($htmlFile in $htmlFiles){
     Set-Content -Path "${pluginFolder}\editors\$($htmlFile.Name)" -Value $minifiedHtml;
 }
 
+# HTML (Back-office Components) - Copy and Minify (or just remove comments)
+$htmlFiles = Get-ChildItem -Path "${ProjectDir}Trees" -Recurse -Force -Include *.html;
+foreach($htmlFile in $htmlFiles){
+    $contents = Get-Content -Path $htmlFile.FullName;
+    $minifiedHtml = [Regex]::Replace($contents, "^<!--.*?-->", "");
+    Set-Content -Path "${pluginFolder}\backoffice\contentment\$($htmlFile.Name)" -Value $minifiedHtml;
+}
+
 # CSS - Bundle & Minify
 $targetCssPath = "${pluginFolder}contentment.css";
-Get-Content -Path "${ProjectDir}DataEditors\**\*.css" | Set-Content -Path $targetCssPath;
+Get-Content -Path "${ProjectDir}**\**\*.css" | Set-Content -Path $targetCssPath;
 & "${SolutionDir}..\tools\AjaxMinifier.exe" $targetCssPath -o $targetCssPath
 
 # JS - Bundle & Minify
 $targetJsPath = "${pluginFolder}contentment.js";
-Get-Content -Path "${ProjectDir}DataEditors\**\*.js" | Set-Content -Path $targetJsPath;
+Get-Content -Path "${ProjectDir}**\**\*.js" | Set-Content -Path $targetJsPath;
 & "${SolutionDir}..\tools\AjaxMinifier.exe" $targetJsPath -o $targetJsPath
 
 # In debug mode, copy the assets over to the local dev website

--- a/src/Umbraco.Community.Contentment/Constants.cs
+++ b/src/Umbraco.Community.Contentment/Constants.cs
@@ -23,6 +23,8 @@ namespace Umbraco.Community.Contentment
 
             internal const string PluginControllerName = ProjectName;
 
+            internal const string BackOfficePathRoot = PackagePathRoot + "backoffice/" + TreeAlias + "/";
+
             internal const string TreeAlias = "contentment";
         }
 

--- a/src/Umbraco.Community.Contentment/Core/Services/DataTypeServiceExtensions.cs
+++ b/src/Umbraco.Community.Contentment/Core/Services/DataTypeServiceExtensions.cs
@@ -1,0 +1,46 @@
+﻿/* Copyright © 2019 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System;
+using Umbraco.Core.Models;
+
+namespace Umbraco.Core.Services
+{
+    internal static class DataTypeServiceExtensions
+    {
+        public static Attempt<string> Copy(this IDataTypeService service, int id, int parentId)
+        {
+            var dataType = service.GetDataType(id);
+
+            var parent = parentId > 0
+                ? service.GetContainer(parentId)
+                : default;
+
+            return Copy(service, dataType, parent);
+        }
+
+        public static Attempt<string> Copy(this IDataTypeService service, IDataType dataType, EntityContainer parent)
+        {
+            if (dataType == null)
+            {
+                return Attempt.Fail(string.Empty, new NullReferenceException("Data Type Not Found"));
+            }
+
+            var clone = (IDataType)dataType.DeepClone();
+
+            clone.Id = 0;
+            clone.Key = Guid.Empty;
+
+            if (parent != null)
+            {
+                clone.SetParent(parent);
+            }
+
+            service.Save(clone);
+
+            return Attempt.Succeed(clone.Path);
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/Experience/DataTypeTreeCopyMenuItemComponent.cs
+++ b/src/Umbraco.Community.Contentment/Experience/DataTypeTreeCopyMenuItemComponent.cs
@@ -1,0 +1,52 @@
+﻿/* Copyright © 2019 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System.Linq;
+using Umbraco.Core;
+using Umbraco.Core.Composing;
+using Umbraco.Core.IO;
+using Umbraco.Core.Services;
+using Umbraco.Core.Services.Implement;
+using Umbraco.Web.Models.Trees;
+using Umbraco.Web.Trees;
+
+namespace Umbraco.Community.Contentment.Experience
+{
+    public sealed class DataTypeTreeCopyMenuItemComponent : IComponent
+    {
+        private readonly ILocalizedTextService _textService;
+
+        public DataTypeTreeCopyMenuItemComponent(ILocalizedTextService textService)
+        {
+            _textService = textService;
+        }
+
+        public void Initialize()
+        {
+            TreeControllerBase.MenuRendering += (sender, args) =>
+            {
+                if (sender.TreeAlias.InvariantEquals("dataTypes") == false)
+                    return;
+
+                if (args.NodeId.InvariantEquals(Core.Constants.System.RootString))
+                    return;
+
+                // This is a quicker way to detect if the node is an actual data-type, (not a container).
+                if (args.Menu.Items.Any(x => x.Alias.InvariantEquals("move")) == false)
+                    return;
+
+                args.Menu.Items.Add(new MenuItem("copy", _textService.Localize("actions/copy"))
+                {
+                    Icon = "documents",
+                    OpensDialog = true,
+                    AdditionalData = { { "actionView", IOHelper.ResolveUrl($"{Constants.Internals.BackOfficePathRoot}data-type-copy.html") }, }
+                });
+            };
+        }
+
+        public void Terminate()
+        { }
+    }
+}

--- a/src/Umbraco.Community.Contentment/Trees/DataTypeCopy/DataTypeCopyApiController.cs
+++ b/src/Umbraco.Community.Contentment/Trees/DataTypeCopy/DataTypeCopyApiController.cs
@@ -1,0 +1,34 @@
+﻿/* Copyright © 2019 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System.Net;
+using System.Net.Http;
+using System.Net.Mime;
+using System.Text;
+using Umbraco.Core.Services;
+using Umbraco.Web.Editors;
+using Umbraco.Web.Models.ContentEditing;
+using Umbraco.Web.Mvc;
+using Umbraco.Web.WebApi;
+
+namespace Umbraco.Community.Contentment.Trees
+{
+    [PluginController(Constants.Internals.PluginControllerName), IsBackOffice]
+    public sealed class DataTypeCopyApiController : UmbracoAuthorizedJsonController
+    {
+        public HttpResponseMessage Copy(MoveOrCopy copy)
+        {
+            var result = Services.DataTypeService.Copy(copy.Id, copy.ParentId);
+
+            if (result.Success)
+            {
+                var response = Request.CreateResponse(HttpStatusCode.OK);
+                response.Content = new StringContent(result.Result, Encoding.UTF8, MediaTypeNames.Text.Plain);
+                return response;
+            }
+            return Request.CreateResponse(HttpStatusCode.InternalServerError);
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/Trees/DataTypeCopy/data-type-copy.html
+++ b/src/Umbraco.Community.Contentment/Trees/DataTypeCopy/data-type-copy.html
@@ -1,0 +1,58 @@
+﻿<!-- Copyright © 2013-present Umbraco.
+   - This Source Code has been derived from Umbraco CMS.
+   - https://github.com/umbraco/Umbraco-CMS/blob/release-8.3.0/src/Umbraco.Web.UI.Client/src/views/documenttypes/copy.html
+   - Modified under the permissions of the MIT License.
+   - Modifications are licensed under the Mozilla Public License.
+   - Copyright © 2019 Lee Kelleher.
+   - This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+<div class="umb-dialog" ng-controller="Umbraco.Community.Contentment.Trees.DataTypeCopy.Controller as vm">
+    <div class="umb-dialog-body">
+        <div class="umb-pane">
+
+            <p class="abstract" ng-hide="vm.success">
+                <localize key="contentTypeEditor_folderToCopy">Select the folder to copy</localize> <strong>{{vm.source.name}}</strong>&nbsp;<localize key="contentTypeEditor_structureBelow">to in the tree structure below</localize>
+            </p>
+
+            <umb-loader ng-show="vm.busy"></umb-loader>
+
+            <div ng-show="vm.error">
+                <div class="alert alert-error">
+                    <div><strong>{{vm.error.errorMsg}}</strong></div>
+                    <div>{{vm.error.data.message}}</div>
+                </div>
+            </div>
+
+            <div ng-show="vm.success">
+                <div class="alert alert-success">
+                    <strong>{{vm.source.name}}</strong> <localize key="contentTypeEditor_copiedUnderneath">was copied underneath</localize>&nbsp;<strong>{{vm.target.name}}</strong>
+                </div>
+                <button class="btn btn-primary" ng-click="vm.close()">OK</button>
+            </div>
+
+            <div ng-hide="vm.success">
+                <umb-tree section="settings"
+                          treealias="dataTypes"
+                          customtreeparams="foldersonly=1"
+                          hideheader="false"
+                          hideoptions="true"
+                          isdialog="true"
+                          api="vm.dialogTreeApi"
+                          on-init="vm.initDataTypeTree()"
+                          enablecheckboxes="true">
+                </umb-tree>
+            </div>
+        </div>
+    </div>
+
+    <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="vm.success">
+        <button type="button" class="btn btn-link" ng-click="vm.close()" ng-show="!vm.busy">
+            <localize key="general_cancel">Cancel</localize>
+        </button>
+        <button class="btn btn-primary" ng-click="vm.copy()" ng-disabled="vm.busy || !vm.target">
+            <localize key="actions_copy">Copy</localize>
+        </button>
+    </div>
+</div>

--- a/src/Umbraco.Community.Contentment/Trees/DataTypeCopy/data-type-copy.js
+++ b/src/Umbraco.Community.Contentment/Trees/DataTypeCopy/data-type-copy.js
@@ -1,0 +1,108 @@
+﻿/* Copyright © 2013-present Umbraco.
+ * This Source Code has been derived from Umbraco CMS.
+ * https://github.com/umbraco/Umbraco-CMS/blob/release-8.3.0/src/Umbraco.Web.UI.Client/src/views/documenttypes/copy.controller.js
+ * Modified under the permissions of the MIT License.
+ * Modifications are licensed under the Mozilla Public License.
+ * Copyright © 2019 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+angular.module("umbraco").controller("Umbraco.Community.Contentment.Trees.DataTypeCopy.Controller", [
+    "$scope",
+    "$http",
+    "appState",
+    "navigationService",
+    "treeService",
+    "umbRequestHelper",
+    function ($scope, $http, appState, navigationService, treeService, umbRequestHelper) {
+
+        // console.log("data-type-copy", $scope.currentNode);
+
+        var vm = this;
+
+        function init() {
+
+            vm.busy = false;
+            vm.success = false;
+            vm.error = false;
+
+            vm.source = _.clone($scope.currentNode);
+
+            vm.dialogTreeApi = {};
+            vm.initDataTypeTree = initDataTypeTree;
+
+            vm.copy = copy;
+            vm.close = close;
+        };
+
+        function initDataTypeTree() {
+            vm.dialogTreeApi.callbacks.treeNodeSelect(function (args) {
+
+                args.event.preventDefault();
+                args.event.stopPropagation();
+
+                if (vm.target) {
+                    //un-select if there's a current one selected
+                    vm.target.selected = false;
+                }
+
+                vm.target = args.node;
+                vm.target.selected = true;
+
+            });
+        };
+
+        function copy() {
+
+            vm.busy = true;
+            vm.error = false;
+            vm.success = false;
+
+            umbRequestHelper.resourcePromise(
+                $http.post("backoffice/Contentment/DataTypeCopyApi/Copy", { parentId: vm.target.id, id: vm.source.id }, { responseType: "text" }),
+                "Failed to copy data type")
+                .then(function (path) {
+
+                    vm.busy = false;
+                    vm.error = false;
+                    vm.success = true;
+
+                    //get the currently edited node (if any)
+                    var activeNode = appState.getTreeState("selectedNode");
+
+                    //we need to do a double sync here: first sync to the copied content - but don't activate the node,
+                    //then sync to the currenlty edited content (note: this might not be the content that was copied!!)
+                    navigationService.syncTree({
+                        tree: "dataTypes",
+                        path: path,
+                        forceReload: true,
+                        activate: false
+                    }).then(function (args) {
+                        if (activeNode) {
+                            var activeNodePath = treeService.getPath(activeNode).join();
+                            //sync to this node now - depending on what was copied this might already be synced but might not be
+                            navigationService.syncTree({
+                                tree: "dataTypes",
+                                path: activeNodePath,
+                                forceReload: false,
+                                activate: true
+                            });
+                        }
+                    });
+
+                }, function (error) {
+                    vm.busy = false;
+                    vm.error = error;
+                    vm.success = false;
+                });
+
+        };
+
+        function close() {
+            navigationService.hideDialog();
+        };
+
+        init();
+    }
+]);

--- a/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
+++ b/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
@@ -292,6 +292,7 @@
   <ItemGroup>
     <Compile Include="Configuration\ContentmentVersion.cs" />
     <Compile Include="DataEditors\TextInput\TextInputDataListEditor.cs" />
+    <Compile Include="Experience\DataTypeTreeCopyMenuItemComponent.cs" />
     <Compile Include="Experience\DisablePreviewComponent.cs" />
     <Compile Include="Experience\HidePropertyLabelComponent.cs" />
     <Compile Include="Experience\MarkdownPropertyDescriptionComponent.cs" />
@@ -405,6 +406,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Serialization\ConfigurationFieldJsonSerializerSettings.cs" />
     <Compile Include="Trees\ContentmentTreeController.cs" />
+    <Compile Include="Trees\DataTypeCopy\DataTypeCopyApiController.cs" />
+    <Compile Include="Core\Services\DataTypeServiceExtensions.cs" />
     <Compile Include="Web\Controllers\EnumDataListSourceApiController.cs" />
     <Compile Include="Web\PublishedCache\DetachedPublishedElement.cs" />
     <Compile Include="Web\PublishedCache\DetachedPublishedProperty.cs" />
@@ -470,9 +473,12 @@
     <Content Include="DataEditors\_\_dev-mode.js" />
     <Content Include="DataEditors\_\_empty.html" />
     <Content Include="DataEditors\_\_json-editor.html" />
+    <Content Include="Trees\DataTypeCopy\data-type-copy.html" />
+    <Content Include="Trees\DataTypeCopy\data-type-copy.js" />
     <Content Include="Web\UI\App_Plugins\Contentment\backoffice\contentment\index.html" />
     <Content Include="Web\UI\App_Plugins\Contentment\contentment.css" />
     <Content Include="Web\UI\App_Plugins\Contentment\contentment.js" />
+    <Content Include="Web\UI\App_Plugins\Contentment\lang\en.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Umbraco.SqlServerCE.4.0.0.1\build\Umbraco.SqlServerCE.targets" Condition="Exists('..\packages\Umbraco.SqlServerCE.4.0.0.1\build\Umbraco.SqlServerCE.targets')" />

--- a/src/Umbraco.Community.Contentment/Web/UI/App_Plugins/Contentment/lang/en.xml
+++ b/src/Umbraco.Community.Contentment/Web/UI/App_Plugins/Contentment/lang/en.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
+    <creator>
+        <name>Lee Kelleher</name>
+        <link>https://leekelleher.com</link>
+    </creator>
+    <area alias="contentment">
+        <key alias="name">Contentment</key>
+    </area>
+</language>


### PR DESCRIPTION
### Description

Includes a Component that will add a "Copy..." menu item for Data Types.

This would need to be manually enabled by the web-app in its own start-up `IUserComposer`.

e.g. `composition.Components().Append<DataTypeTreeCopyMenuItemComponent>();`

The main reason for this feature was to easy my own time spent on creating/re-creating DataTypes with varying configurations. By making quick copies, I can swap-and-change my Data Types easily.

### Types of changes

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
