### PR TITLE
build-assets.ps1 creates missing editors folder. TargetDevWebsite with "

### DIFF
--- a/build/build-assets.ps1
+++ b/build/build-assets.ps1
@@ -34,15 +34,12 @@ $pluginFolder = "${targetFolder}\App_Plugins\Contentment\";
 if (!(Test-Path -Path $pluginFolder)) {New-Item -Path $pluginFolder -Type Directory;}
 Copy-Item -Path "${ProjectDir}Web\UI\App_Plugins\Contentment\*" -Force -Recurse -Destination "${pluginFolder}";
 
-
 # HTML (Property Editors) - Copy and Minify (or just remove comments)
-$editorFolder = "${pluginFolder}\editors"
-if (!(Test-Path -Path $editorFolder)) {New-Item -Path $editorFolder -Type Directory;}
 $htmlFiles = Get-ChildItem -Path "${ProjectDir}DataEditors" -Recurse -Force -Include *.html;
 foreach($htmlFile in $htmlFiles){
     $contents = Get-Content -Path $htmlFile.FullName;
     $minifiedHtml = [Regex]::Replace($contents, "^<!--.*?-->", "");
-    Set-Content -Path "$editorFolder\$($htmlFile.Name)" -Value $minifiedHtml;
+    Set-Content -Path "${pluginFolder}\editors\$($htmlFile.Name)" -Value $minifiedHtml;
 }
 
 # HTML (Back-office Components) - Copy and Minify (or just remove comments)

--- a/build/build-assets.ps1
+++ b/build/build-assets.ps1
@@ -34,12 +34,15 @@ $pluginFolder = "${targetFolder}\App_Plugins\Contentment\";
 if (!(Test-Path -Path $pluginFolder)) {New-Item -Path $pluginFolder -Type Directory;}
 Copy-Item -Path "${ProjectDir}Web\UI\App_Plugins\Contentment\*" -Force -Recurse -Destination "${pluginFolder}";
 
+
 # HTML (Property Editors) - Copy and Minify (or just remove comments)
+$editorFolder = "${pluginFolder}\editors"
+if (!(Test-Path -Path $editorFolder)) {New-Item -Path $editorFolder -Type Directory;}
 $htmlFiles = Get-ChildItem -Path "${ProjectDir}DataEditors" -Recurse -Force -Include *.html;
 foreach($htmlFile in $htmlFiles){
     $contents = Get-Content -Path $htmlFile.FullName;
     $minifiedHtml = [Regex]::Replace($contents, "^<!--.*?-->", "");
-    Set-Content -Path "${pluginFolder}\editors\$($htmlFile.Name)" -Value $minifiedHtml;
+    Set-Content -Path "$editorFolder\$($htmlFile.Name)" -Value $minifiedHtml;
 }
 
 # HTML (Back-office Components) - Copy and Minify (or just remove comments)

--- a/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
+++ b/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
@@ -496,6 +496,6 @@
     <Error Condition="!Exists('..\packages\Umbraco.SqlServerCE.4.0.0.1\build\Umbraco.SqlServerCE.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Umbraco.SqlServerCE.4.0.0.1\build\Umbraco.SqlServerCE.targets'))" />
   </Target>
   <PropertyGroup>
-    <PostBuildEvent>powershell -NoProfile -ExecutionPolicy RemoteSigned -file $(SolutionDir)..\build\build-assets.ps1 -SolutionDir $(SolutionDir) -TargetDir $(TargetDir) -ProjectName $(ProjectName) -ProjectDir $(ProjectDir) -TargetDevWebsite $(TargetDevWebsite) -ConfigurationName $(ConfigurationName)</PostBuildEvent>
+    <PostBuildEvent>powershell -NoProfile -ExecutionPolicy RemoteSigned -file $(SolutionDir)..\build\build-assets.ps1 -SolutionDir $(SolutionDir) -TargetDir $(TargetDir) -ProjectName $(ProjectName) -ProjectDir $(ProjectDir) -TargetDevWebsite "$(TargetDevWebsite)" -ConfigurationName $(ConfigurationName)</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Had a two build errors after initial clone: 1) missing editors folder in ps1 file and 2) TargetDevWebsite in build configuration gave an error because empty. Added "" in build parameters.