### PR TITLE
Add Image Button List DataListEditor (using SVG sprites)

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/ImageButtonList/ImageButtonListConfigurationEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/ImageButtonList/ImageButtonListConfigurationEditor.cs
@@ -1,0 +1,60 @@
+﻿/* Copyright © 2019 Lee Kelleher and Marc Stöcker.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System.Collections.Generic;
+using Umbraco.Core.IO;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    internal sealed class ImageButtonListConfigurationEditor : ConfigurationEditor
+    {
+        internal const string Items = "items";
+        internal const string DefaultValue = "defaultValue";
+
+        public ImageButtonListConfigurationEditor()
+            : base()
+        {
+            var listFields = new[]
+            {
+                new ConfigurationField
+                {
+                    Key = "name",
+                    Name = "Name",
+                    View = "textbox"
+                },
+                new ConfigurationField
+                {
+                    Key = "description",
+                    Name = "Description",
+                    View = "textbox"
+                },
+                new ConfigurationField
+                {
+                    Key = "value",
+                    Name = "Value",
+                    View = "textbox"
+                }
+            };
+
+            Fields.Add(
+                Items,
+                "Options",
+                "Configure the option items for the image button list.",
+                IOHelper.ResolveUrl(DataTableDataEditor.DataEditorViewPath),
+                new Dictionary<string, object>()
+                {
+                    { DataTableConfigurationEditor.FieldItems, listFields },
+                    { MaxItemsConfigurationField.MaxItems, 0 },
+                    { DisableSortingConfigurationField.DisableSorting, Constants.Values.False },
+                    { DataTableConfigurationEditor.RestrictWidth, Constants.Values.True },
+                    { DataTableConfigurationEditor.UsePrevalueEditors, Constants.Values.False }
+                });
+
+            Fields.Add(new ShowDescriptionsConfigurationField());
+            Fields.Add(new SvgSpriteMediaConfigurationField());
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/ImageButtonList/ImageButtonListDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/ImageButtonList/ImageButtonListDataEditor.cs
@@ -1,0 +1,37 @@
+﻿/* Copyright © 2019 Lee Kelleher and Marc Stöcker.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using Umbraco.Core.Logging;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    [DataEditor(
+        DataEditorAlias,
+        EditorType.PropertyValue,
+        DataEditorName,
+        DataEditorViewPath,
+        ValueType = ValueTypes.String,
+        Group = Core.Constants.PropertyEditors.Groups.Lists,
+#if DEBUG
+        Icon = "icon-block color-red"
+#else
+        Icon = DataEditorIcon
+#endif
+        )]
+    internal sealed class ImageButtonListDataEditor : DataEditor
+    {
+        internal const string DataEditorAlias = Constants.Internals.DataEditorAliasPrefix + "ImageButtonList";
+        internal const string DataEditorName = Constants.Internals.DataEditorNamePrefix + "Image Button List";
+        internal const string DataEditorViewPath = Constants.Internals.EditorsPathRoot + "image-button-list.html";
+        internal const string DataEditorIcon = "icon-columns"; //icon-pictures-alt
+
+        public ImageButtonListDataEditor(ILogger logger)
+            : base(logger)
+        { }
+
+        protected override IConfigurationEditor CreateConfigurationEditor() => new ImageButtonListConfigurationEditor();
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/ImageButtonList/ImageButtonListDataListEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/ImageButtonList/ImageButtonListDataListEditor.cs
@@ -1,0 +1,33 @@
+﻿/* Copyright © 2019 Lee Kelleher and Marc Stöcker.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System.Collections.Generic;
+using Umbraco.Core;
+using Umbraco.Core.IO;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    internal sealed class ImageButtonListDataListEditor : IDataListEditor
+    {
+        public string Name => "Image Button List";
+
+        public string Description => "Select a single image from a list of image buttons";
+
+        public string Icon => ImageButtonListDataEditor.DataEditorIcon;
+
+        public Dictionary<string, object> DefaultValues => default;
+
+        public Dictionary<string, object> DefaultConfig => default;
+
+        public string View => IOHelper.ResolveUrl(ImageButtonListDataEditor.DataEditorViewPath);
+
+        [ConfigurationField(typeof(ShowDescriptionsConfigurationField))]
+        public bool ShowDescriptions { get; set; }
+
+        [ConfigurationField(typeof(SvgSpriteMediaConfigurationField))]
+        public Udi SvgSpriteMedia { get; set; }
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/ImageButtonList/ImageButtonListValueConverter.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/ImageButtonList/ImageButtonListValueConverter.cs
@@ -1,0 +1,21 @@
+﻿/* Copyright © 2019 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System;
+using Umbraco.Core;
+using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    internal sealed class ImageButtonListValueConverter : PropertyValueConverterBase
+    {
+        public override bool IsConverter(IPublishedPropertyType propertyType) => propertyType.EditorAlias.InvariantEquals(ImageButtonListDataEditor.DataEditorAlias);
+
+        public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Element;
+
+        public override Type GetPropertyValueType(IPublishedPropertyType propertyType) => typeof(string);
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/ImageButtonList/image-button-list.css
+++ b/src/Umbraco.Community.Contentment/DataEditors/ImageButtonList/image-button-list.css
@@ -1,0 +1,55 @@
+﻿/* Copyright © 2019 Marc Stöcker.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+.contentment.umb-imagebuttons ul.radio {
+    margin-bottom: 15px;
+}
+
+.contentment.umb-imagebuttons ul.radio li {
+    display: inline-block;
+    margin-right:15px;
+    margin-bottom: 5px;
+
+    border: 1px solid #f6f4f4;
+    padding:5px;
+}
+
+.contentment.umb-imagebuttons .image-selector input {
+    margin: 0;
+    padding: 0;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+}
+
+.contentment.umb-imagebuttons .imagebutton-icon {
+    width: 110px;
+    height: 110px;
+    display: inline-block;
+    overflow: hidden;
+}
+
+.contentment.umb-imagebuttons .image-selector input:active + .sprite-image {
+    opacity: .9;
+}
+
+.contentment.umb-imagebuttons .image-selector input:checked + .sprite-image {
+    filter: none;
+}
+
+.contentment.umb-imagebuttons .sprite-image {
+    cursor: pointer;
+    background-size: contain;
+    background-repeat: no-repeat;
+    display: inline-block;
+    width: 110px;
+    height: 110px;
+    transition: all 100ms ease-in;
+    filter: brightness(1.8) grayscale(1) opacity(.7);
+}
+
+.contentment.umb-imagebuttons .sprite-image:hover {
+    filter: brightness(1.2) grayscale(.5) opacity(.9);
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/ImageButtonList/image-button-list.html
+++ b/src/Umbraco.Community.Contentment/DataEditors/ImageButtonList/image-button-list.html
@@ -1,0 +1,22 @@
+﻿<!-- Copyright © 2013-present Umbraco.
+   - Parts of this Source Code has been derived from Umbraco CMS.
+   - https://github.com/umbraco/Umbraco-CMS/blob/release-8.1.5/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
+   - Modified under the permissions of the MIT License.
+   - Modifications are licensed under the Mozilla Public License.
+   - Copyright © 2019 Lee Kelleher and Marc Stöcker.
+   - This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+<div class="contentment umb-imagebuttons" ng-class="vm.uniqueId" ng-controller="Umbraco.Community.Contentment.DataEditors.ImageButtonList.Controller as vm">
+    <ul class="unstyled radio no-indent image-selector">
+        <li ng-repeat="item in vm.items">
+            <input type="radio" value="{{item.value}}" ng-model="model.value" ng-disabled="item.disabled" id="{{vm.uniqueId + '_' + item.value}}" />
+            <label for="{{vm.uniqueId + '_' + item.value}}" class="sprite-image" ng-class="{ 'umb-form-check--disabled': item.disabled }" title="{{item.name}}">
+                <svg class="imagebutton-icon">
+                    <use ng-href="{{vm.svgSpriteUrl}}#{{item.value}}" xlink:href="" />
+                </svg>
+            </label>
+        </li>
+    </ul>
+</div>

--- a/src/Umbraco.Community.Contentment/DataEditors/ImageButtonList/image-button-list.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/ImageButtonList/image-button-list.js
@@ -1,0 +1,41 @@
+﻿/* Copyright © 2019 Marc Stöcker.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.ImageButtonList.Controller", [
+    "$scope",
+    "mediaResource",
+    function($scope, mediaResource) {
+
+        // console.log("imagebuttonlist.model", $scope.model);
+
+        var defaultConfig = { items: [], showDescriptions: 1, svgSpriteMedia: null, defaultValue: "" };
+        var config = angular.extend({}, defaultConfig, $scope.model.config);
+        
+        var vm = this;
+
+        function init() {
+            $scope.model.value = $scope.model.value || config.defaultValue;
+
+            if (_.isArray($scope.model.value)) {
+                $scope.model.value = _.first($scope.model.value);
+            }
+
+            vm.items = angular.copy(config.items);
+
+            vm.uniqueId = [$scope.model.alias, $scope.model.dataTypeKey.substring(0, 8)].join("-");
+            vm.showDescriptions = Object.toBoolean(config.showDescriptions);
+            vm.svgSpriteMedia = config.svgSpriteMedia;
+
+            //console.log("svgSpriteMedia", vm.svgSpriteMedia);
+            mediaResource.getById(vm.svgSpriteMedia)
+                .then(function(media) {
+                    vm.svgSpriteUrl = media.mediaLink;
+                    //console.log("fetched sprite media", media);
+                });
+        };
+
+        init();
+    }
+]);

--- a/src/Umbraco.Community.Contentment/DataEditors/_/ConfigurationFields/SvgSpriteMediaConfigurationField.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/_/ConfigurationFields/SvgSpriteMediaConfigurationField.cs
@@ -1,0 +1,23 @@
+﻿/* Copyright © 2019 Marc Stöcker.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    internal sealed class SvgSpriteMediaConfigurationField : ConfigurationField
+    {
+        internal const string SpriteMedia = "svgSpriteMedia";
+
+        public SvgSpriteMediaConfigurationField()
+            : base()
+        {
+            Key = SpriteMedia;
+            Name = "SVG Sprite";
+            Description = "Choose the SVG sprite media file to use.";
+            View = "mediapicker";
+        }
+    }
+}


### PR DESCRIPTION
This adds an Image Button List based on SVG sprites (from the media library) to the available Data List Editors.

![image](https://user-images.githubusercontent.com/1537988/70890904-6e330d00-1fe6-11ea-9c80-87cbb911d256.png)

### Description

Choosing visually from options is much easier for users than reading und understanding a text description of the same thing. This PR provides an SVG-based image selection approach. The list option's value is used as the SVG fragment identifier. 

https://twitter.com/MarcStoecker/status/1204877938140893184

### Types of changes
- [x] New feature _(non-breaking change which adds functionality)_

### Checklist
- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [x] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
