### PR TITLE
Add info about the value of the Icon Picker property editor

### DIFF
--- a/docs/editors/icon-picker.md
+++ b/docs/editors/icon-picker.md
@@ -33,7 +33,7 @@ Having picked your icon, the selected icon will be displayed in the icon box.
 
 ### How to get the value?
 
-The value for the Icon Picker is a `string`. To use this in your view templates, here are some examples.
+The value for the Icon Picker is a `string` in the form of `"icon-{name} color-{name}"` (e.g. `"icon-hat color-black"`). To use this in your view templates, here are some examples.
 
 Assuming that your property's alias is `"icon"`, then...
 


### PR DESCRIPTION
### Description

I was looking through the docs, trying to see what kind of value hte Icon Picker returns (e.g. was it a custom object with `.Icon` and `.Color` properties or maybe a string like `"pink home"` ?). I figure others will have the same question, so I put it in as where it currently just says `string`.

### Related Issues?

No related issues.

### Types of changes

- [x] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [x] My change requires a change to the documentation.
- [x] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
