### PR TITLE
Content Blocks - adds preview feature

### DIFF
--- a/build/build-assets.ps1
+++ b/build/build-assets.ps1
@@ -48,6 +48,13 @@ foreach($htmlFile in $htmlFiles){
     Set-Content -Path "${pluginFolder}\editors\$($htmlFile.Name)" -Value $minifiedHtml;
 }
 
+# Razor Templates - Copy
+$razorFiles = Get-ChildItem -Path "${ProjectDir}DataEditors" -Recurse -Force -Include *.cshtml;
+foreach($razorFile in $razorFiles){
+    $contents = Get-Content -Path $razorFile.FullName;
+    Set-Content -Path "${pluginFolder}\render\$($razorFile.Name)" -Value $contents;
+}
+
 # CSS - Bundle & Minify
 $targetCssPath = "${pluginFolder}contentment.css";
 Get-Content -Path "${ProjectDir}**\**\*.css" | Set-Content -Path $targetCssPath;

--- a/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlockPreview.cshtml
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlockPreview.cshtml
@@ -1,0 +1,12 @@
+﻿@* Copyright © 2019 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. *@
+@inherits Umbraco.Web.Mvc.ContentBlockPreviewView
+@{
+    var elementIcon = ViewData.ContainsKey("elementIcon") == true ? ViewData["elementIcon"] : "icon-brick";
+}
+<div class="lk-content-blocks__preview--default">
+    <i class="icon @elementIcon"></i>
+    <h5>@Model.Element.Key</h5>
+</div>

--- a/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlockPreviewModel.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlockPreviewModel.cs
@@ -1,0 +1,27 @@
+﻿/* Copyright © 2020 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Web.Models;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    public class ContentBlockPreviewModel : ContentBlockPreviewModel<IPublishedContent, IPublishedElement>
+    {
+        public ContentBlockPreviewModel(IPublishedContent content, IPublishedElement element)
+        { }
+    }
+
+    public class ContentBlockPreviewModel<TPublishedContent, TPublishedElement> : IContentModel
+        where TPublishedContent : IPublishedContent
+        where TPublishedElement : IPublishedElement
+    {
+        IPublishedContent IContentModel.Content => Content;
+
+        public TPublishedContent Content { get; internal set; }
+
+        public TPublishedElement Element { get; internal set; }
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlockPreviewView.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlockPreviewView.cs
@@ -1,0 +1,40 @@
+﻿/* Copyright © 2020 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System.Web.Mvc;
+using Umbraco.Community.Contentment.DataEditors;
+using Umbraco.Core.Models.PublishedContent;
+
+namespace Umbraco.Web.Mvc
+{
+    public abstract class ContentBlockPreviewView
+        : ContentBlockPreviewView<IPublishedContent, IPublishedElement>
+    { }
+
+    public abstract class ContentBlockPreviewView<TPublishedContent, TPublishedElement>
+        : UmbracoViewPage<ContentBlockPreviewModel<TPublishedContent, TPublishedElement>>
+        where TPublishedContent : IPublishedContent
+        where TPublishedElement : IPublishedElement
+    {
+        protected override void SetViewData(ViewDataDictionary viewData)
+        {
+            var model = new ContentBlockPreviewModel<TPublishedContent, TPublishedElement>();
+
+            if (viewData.TryGetValue("content", out var tmp1) && tmp1 is TPublishedContent t1)
+            {
+                model.Content = t1;
+            }
+
+            if (viewData.TryGetValue("element", out var tmp2) && tmp2 is TPublishedElement t2)
+            {
+                model.Element = t2;
+            }
+
+            viewData.Model = model;
+
+            base.SetViewData(viewData);
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlockType.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlockType.cs
@@ -30,6 +30,8 @@ namespace Umbraco.Community.Contentment.DataEditors
 
         public string OverlaySize { get; set; }
 
+        public bool PreviewEnabled { get; set; }
+
         public IEnumerable<BlueprintItem> Blueprints { get; set; }
 
         [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]

--- a/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlocksApiController.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlocksApiController.cs
@@ -1,0 +1,110 @@
+﻿/* Copyright © 2019 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+using Newtonsoft.Json.Linq;
+using Umbraco.Community.Contentment.Web.PublishedCache;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Web.Editors;
+using Umbraco.Web.Mvc;
+using Umbraco.Web.WebApi;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    [PluginController(Constants.Internals.PluginControllerName), IsBackOffice]
+    public sealed class ContentBlocksApiController : UmbracoAuthorizedJsonController
+    {
+        private readonly ILogger _logger;
+        private readonly IPublishedModelFactory _publishedModelFactory;
+
+        public ContentBlocksApiController(ILogger logger, IPublishedModelFactory publishedModelFactory)
+        {
+            _logger = logger;
+            _publishedModelFactory = publishedModelFactory;
+        }
+
+        [HttpPost]
+        public HttpResponseMessage GetPreviewMarkup([FromBody] JObject item, int elementIndex, Guid elementKey, int contentId)
+        {
+            var preview = true;
+
+            var content = UmbracoContext.Content.GetById(true, contentId);
+            if (content == null)
+            {
+                // TODO: [LK] What to do with an unsaved (new) page?
+            }
+
+            var element = default(IPublishedElement);
+            var block = item.ToObject<ContentBlock>();
+            if (block != null && block.ElementType.Equals(Guid.Empty) == false)
+            {
+                if (ContentTypeCacheHelper.TryGetAlias(block.ElementType, out var alias, Services.ContentTypeService) == true)
+                {
+                    var contentType = UmbracoContext.PublishedSnapshot.Content.GetContentType(alias);
+                    if (contentType != null && contentType.IsElement == true)
+                    {
+                        var properties = new List<IPublishedProperty>();
+
+                        foreach (var thing in block.Value)
+                        {
+                            var propType = contentType.GetPropertyType(thing.Key);
+                            if (propType != null)
+                            {
+                                properties.Add(new DetachedPublishedProperty(propType, null, thing.Value, preview));
+                            }
+                        }
+
+                        element = _publishedModelFactory.CreateModel(new DetachedPublishedElement(block.Key, contentType, properties));
+                    }
+                }
+            }
+
+            var viewData = new System.Web.Mvc.ViewDataDictionary()
+            {
+                { nameof(content), content },
+                { nameof(element), element },
+                { nameof(elementIndex), elementIndex }
+            };
+
+            if (ContentTypeCacheHelper.TryGetIcon(content.ContentType.Alias, out var contentIcon, Services.ContentTypeService) == true)
+            {
+                viewData.Add(nameof(contentIcon), contentIcon);
+            }
+
+            if (ContentTypeCacheHelper.TryGetIcon(element.ContentType.Alias, out var elementIcon, Services.ContentTypeService) == true)
+            {
+                viewData.Add(nameof(elementIcon), elementIcon);
+            }
+
+            var markup = default(string);
+
+            try
+            {
+                markup = ContentBlocksViewHelper.RenderPartial(element.ContentType.Alias, viewData);
+            }
+            catch (InvalidCastException icex)
+            {
+                // NOTE: This type of exception happens on a new (unsaved) page, when the context becomes the parent page,
+                // and the preview view is strongly typed to the current page's model type.
+                markup = "<p class=\"text-center mt4\">Unable to render the preview until the page has been saved.</p>";
+
+                _logger.Error<ContentBlocksApiController>(icex, "Error rendering preview view.");
+            }
+            catch (Exception ex)
+            {
+                markup = $"<pre><code>{ex}</code></pre>";
+
+                _logger.Error<ContentBlocksApiController>(ex, "Error rendering preview view.");
+            }
+
+            return Request.CreateResponse(HttpStatusCode.OK, new { elementKey, markup });
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlocksConfigurationEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlocksConfigurationEditor.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Umbraco.Core;
 using Umbraco.Core.IO;
@@ -77,6 +78,7 @@ namespace Umbraco.Community.Contentment.DataEditors
                             Blueprints = blueprints,
                             NameTemplate = settings?.ContainsKey("nameTemplate") == true ? settings["nameTemplate"].ToString() : null,
                             OverlaySize = settings?.ContainsKey("overlaySize") == true ? settings["overlaySize"].ToString() : null,
+                            PreviewEnabled = settings?.ContainsKey("enablePreview") == true && settings["enablePreview"].TryConvertTo<bool>().ResultOr(false),
                         });
                     }
                 }

--- a/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlocksDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlocksDataEditor.cs
@@ -79,6 +79,7 @@ namespace Umbraco.Community.Contentment.DataEditors
 
                 if (config.TryGetValueAs(ContentBlocksDisplayModeConfigurationField.DisplayMode, out string displayMode))
                 {
+                    config["enablePreview"] = ContentBlocksDisplayModeConfigurationField.SupportsPreview(displayMode);
                     view = displayMode;
                 }
             }

--- a/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlocksDisplayModeConfigurationField.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlocksDisplayModeConfigurationField.cs
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 using System.Collections.Generic;
+using Umbraco.Core;
 using Umbraco.Core.IO;
 using Umbraco.Core.PropertyEditors;
 
@@ -27,12 +28,23 @@ namespace Umbraco.Community.Contentment.DataEditors
                 { Constants.Conventions.ConfigurationFieldAliases.Items, new DataListItem[]
                     {
                         new DataListItem { Name = nameof(Blocks), Value = Blocks, Description = "This will display as stacked blocks." },
-                        new DataListItem { Name = nameof(List), Value = List, Description = "This will display similar to a content picker." },
+                        new DataListItem { Name = nameof(List), Value = List, Description = "This will display similar to a content picker. Please note, if block preview is enabled, they will not be displayed in this view." },
                     }
                 },
                 { ShowDescriptionsConfigurationField.ShowDescriptions, Constants.Values.True },
                 { Constants.Conventions.ConfigurationFieldAliases.DefaultValue, defaultValue }
             };
+        }
+
+        internal static bool SupportsPreview(string displayMode)
+        {
+            // NOTE: Currently only the stacked blocks support the preview feature.
+            if (displayMode.InvariantEquals(Blocks) == true)
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlocksTypesConfigurationField.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlocksTypesConfigurationField.cs
@@ -51,6 +51,17 @@ namespace Umbraco.Community.Contentment.DataEditors
                         },
                         { Constants.Conventions.ConfigurationFieldAliases.DefaultValue, "small" }
                     }
+                },
+                new ConfigurationField
+                {
+                    Key = "enablePreview",
+                    Name = "Enable preview?",
+                    Description = "Select to enable a rich preview for this content block type.",
+                    View = "views/propertyeditors/boolean/boolean.html",
+                    Config = new Dictionary<string, object>
+                    {
+                        { "default", Constants.Values.False }
+                    }
                 }
             };
 

--- a/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlocksViewHelper.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlocksViewHelper.cs
@@ -1,0 +1,50 @@
+﻿/* Copyright © 2020 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System.IO;
+using System.Web;
+using System.Web.Mvc;
+using System.Web.Routing;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    internal static class ContentBlocksViewHelper
+    {
+        private class FakeController : Controller { }
+
+        private static readonly RazorViewEngine _viewEngine = new RazorViewEngine
+        {
+            PartialViewLocationFormats = new[]
+            {
+                "~/Views/Partials/Blocks/{0}.cshtml",
+                "~/Views/Partials/Blocks/Default.cshtml",
+                Constants.Internals.PackagePathRoot + "render/ContentBlockPreview.cshtml"
+            }
+        };
+
+        internal static string RenderPartial(string partialName, ViewDataDictionary viewData)
+        {
+            using (var sw = new StringWriter())
+            {
+                var httpContext = new HttpContextWrapper(HttpContext.Current);
+
+                var routeData = new RouteData { Values = { { "controller", nameof(FakeController) } } };
+
+                var controllerContext = new ControllerContext(new RequestContext(httpContext, routeData), new FakeController());
+
+                var viewResult = _viewEngine.FindPartialView(controllerContext, partialName, false);
+
+                if (viewResult.View == null)
+                {
+                    return null;
+                }
+
+                viewResult.View.Render(new ViewContext(controllerContext, viewResult.View, viewData, new TempDataDictionary(), sw), sw);
+
+                return sw.ToString();
+            }
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/content-blocks.css
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/content-blocks.css
@@ -3,81 +3,130 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-.contentment.lk-content-blocks .umb-group-builder__properties {
-    padding: 0;
-    min-height: inherit;
+.lk-content-blocks__container {
     max-width: 845px;
 }
 
-.contentment.lk-content-blocks .umb-group-builder__property {
-    border-bottom: none;
+.lk-content-blocks__block {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    margin-bottom: 10px;
 }
 
-    .contentment.lk-content-blocks .umb-group-builder__property:last-of-type {
-        margin-bottom: 0;
+    .lk-content-blocks__block .lk-content-blocks__preview {
+        flex: 1;
+        position: relative;
     }
 
-.contentment.lk-content-blocks .umb-group-builder__property-actions {
-    margin-top: 10px;
-}
-
-.contentment.lk-content-blocks .umb-group-builder__property-action {
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-    .contentment.lk-content-blocks .umb-group-builder__property-action > i.icon {
-        font-size: 18px;
-        padding: 5px 10px;
-    }
-
-    .contentment.lk-content-blocks .umb-group-builder__property-action > .icon {
-        color: #1b264f;
-    }
-
-        .contentment.lk-content-blocks .umb-group-builder__property-action > .icon:hover {
-            color: #2152a3;
+        .lk-content-blocks__block .lk-content-blocks__preview:after {
+            content: "";
+            background: rgba(225, 225, 225, 0.5);
+            border-radius: 3px;
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            transition: opacity .12s;
         }
 
-    .contentment.lk-content-blocks .umb-group-builder__property-action .umb-property-actions {
-        float: none;
-    }
-
-    .contentment.lk-content-blocks .umb-group-builder__property-action .umb-property-actions__toggle {
-        margin-top: 5px;
-        margin-left: 12px;
-        opacity: 1;
-        background-color: transparent;
-    }
-
-        .contentment.lk-content-blocks .umb-group-builder__property-action .umb-property-actions__toggle:hover {
-            background-color: #f9f6f5;
+        .lk-content-blocks__block .lk-content-blocks__preview:hover:after {
+            opacity: .66;
         }
 
-    .contentment.lk-content-blocks .umb-group-builder__property-action .umb-property-actions__menu {
-        margin-left: 12px;
+        .lk-content-blocks__block .lk-content-blocks__preview .lk-content-blocks__preview--left {
+            background-color: #fff;
+            border-radius: 3px;
+            display: flex;
+            flex-direction: row;
+            font-size: 12px;
+            padding: 0 5px;
+            position: absolute;
+            top: 5px;
+            left: 5px;
+            z-index: 20;
+        }
+
+            .lk-content-blocks__block .lk-content-blocks__preview .lk-content-blocks__preview--left .icon {
+                padding-right: 3px;
+            }
+
+        .lk-content-blocks__block .lk-content-blocks__preview .lk-content-blocks__preview--default {
+            text-align: center;
+            padding: 30px 10px 15px;
+        }
+
+            .lk-content-blocks__block .lk-content-blocks__preview .lk-content-blocks__preview--default .icon {
+                display: block;
+                font-size: 40px;
+            }
+
+            .lk-content-blocks__block .lk-content-blocks__preview .lk-content-blocks__preview--default h5 {
+                font-size: 14px;
+            }
+
+        .lk-content-blocks__block .lk-content-blocks__preview button.lk-content-blocks__edit {
+            background: transparent;
+            border: none;
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            z-index: 25;
+        }
+
+            .lk-content-blocks__block .lk-content-blocks__preview button.lk-content-blocks__edit:focus {
+                outline: 0;
+                border: 1px solid #bbbabf;
+            }
+
+    .lk-content-blocks__block .lk-content-blocks__actions {
+        flex: 0 0 34px;
+        padding: 10px 0 0 7px;
+        margin: 0;
+        list-style: none;
     }
 
-.contentment.lk-content-blocks .umb-group-builder__property-preview {
-    height: auto;
-    padding: 30px 10px 5px;
-}
+        .lk-content-blocks__block .lk-content-blocks__actions .lk-content-blocks__action--item {
+        }
 
-.contentment.lk-content-blocks .lk-content-blocks-preview-default {
-    text-align: center;
-    padding-top: 5px;
-    padding-bottom: 20px;
-}
+            .lk-content-blocks__block .lk-content-blocks__actions .lk-content-blocks__action--item > .icon {
+                color: #1b264f;
+                font-size: 18px;
+                padding: 5px 10px;
+            }
 
-    .contentment.lk-content-blocks .lk-content-blocks-preview-default .icon {
-        font-size: 40px;
-    }
+                .lk-content-blocks__block .lk-content-blocks__actions .lk-content-blocks__action--item > .icon:hover {
+                    color: #2152a3;
+                }
 
-    .contentment.lk-content-blocks .lk-content-blocks-preview-default > div {
-        font-size: 14px;
-        font-weight: bold;
-    }
+            .lk-content-blocks__block .lk-content-blocks__actions .lk-content-blocks__action--item > button {
+                background: none;
+                border: none;
+                font-size: 18px;
+                cursor: pointer;
+                color: #162335;
+                margin: 0;
+                padding: 5px 10px;
+            }
 
-.contentment.lk-content-blocks .umb-node-preview-add {
+        .lk-content-blocks__block .lk-content-blocks__actions .umb-property-actions {
+            display: block;
+            float: none;
+            margin: 5px 0 0 6px;
+        }
+
+        .lk-content-blocks__block .lk-content-blocks__actions .umb-property-actions__toggle {
+            opacity: 1;
+            background-color: transparent;
+        }
+
+            .lk-content-blocks__block .lk-content-blocks__actions .umb-property-actions__toggle:hover {
+                background-color: #f9f6f5;
+            }
+
+.lk-content-blocks .umb-node-preview-add {
     margin-right: 45px;
 }

--- a/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/content-blocks.html
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/content-blocks.html
@@ -4,39 +4,44 @@
    - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
 
 <div class="contentment lk-content-blocks" ng-controller="Umbraco.Community.Contentment.DataEditors.ContentBlocks.Controller as vm">
-    <ul class="umb-group-builder__properties" ui-sortable="vm.sortableOptions" ng-model="model.value">
-        <li ng-repeat="item in model.value">
-            <div class="umb-group-builder__property">
+    <div class="lk-content-blocks__container" ui-sortable="vm.sortableOptions" ng-model="model.value">
+        <div class="lk-content-blocks__block" ng-repeat="item in model.value">
 
-                <div tabindex="-1" class="umb-group-builder__property-preview">
-                    <div class="umb-group-builder__property-tags"></div>
-                    <div class="umb-group-builder__property-tags -right"></div>
-                    <div class="umb-group-builder__property-preview-form">
-                        <div class="lk-content-blocks-preview-default">
-                            <i class="icon" ng-class="item.icon"></i>
-                            <div ng-bind="vm.populateName(item, $index)"></div>
-                        </div>
-                    </div>
-                    <button aria-label="Edit content" type="button" class="umb-group-builder__open-settings" ng-click="vm.edit($index)"></button>
+            <div tabindex="-1" class="lk-content-blocks__preview">
+                <div class="lk-content-blocks__preview--left" ng-if="vm.previews[item.key]">
+                    <i class="icon" ng-class="item.icon"></i>
+                    <span ng-bind="vm.populateName(item, $index)"></span>
                 </div>
-
-                <div class="umb-group-builder__property-actions">
-                    <div>
-                        <div class="umb-group-builder__property-action umb-node-preview--sortable" title="Sort" ng-if="vm.sortable">
-                            <i class="icon icon-navigation"></i>
-                        </div>
-                        <div class="umb-group-builder__property-action" title="Remove" ng-if="vm.allowRemove">
-                            <button aria-label="Delete content block" type="button" class="icon icon-trash" ng-click="vm.remove($index)"></button>
-                        </div>
-                        <div class="umb-group-builder__property-action" ng-if="vm.blockActions[$index]">
-                            <umb-property-actions actions="vm.blockActions[$index]"></umb-property-actions>
-                        </div>
+                <div class="lk-content-blocks__preview--main">
+                    <div class="lk-content-blocks__preview--default" ng-if="!vm.previews[item.key]">
+                        <i class="icon" ng-class="item.icon"></i>
+                        <h5 ng-bind="vm.populateName(item, $index)"></h5>
+                    </div>
+                    <div class="lk-content-blocks__preview--markup" ng-if="vm.previews[item.key]">
+                        <umb-load-indicator ng-show="vm.previews[item.key].loading" />
+                        <div ng-bind-html="vm.previews[item.key].markup | safe_html"></div>
                     </div>
                 </div>
-
+                <button aria-label="Edit content"
+                        type="button"
+                        class="lk-content-blocks__edit"
+                        ng-click="vm.edit($index)"></button>
             </div>
-        </li>
-    </ul>
+
+            <ul class="lk-content-blocks__actions">
+                <li aria-label="Sort" class="lk-content-blocks__action--item umb-node-preview--sortable" ng-if="vm.sortable">
+                    <i class="icon icon-navigation"></i>
+                </li>
+                <li class="lk-content-blocks__action--item" ng-if="vm.allowRemove">
+                    <button aria-label="Delete content block" type="button" class="icon icon-trash" ng-click="vm.remove($index)"></button>
+                </li>
+                <li class="lk-content-blocks__action--item" ng-if="vm.blockActions[$index]">
+                    <umb-property-actions actions="vm.blockActions[$index]"></umb-property-actions>
+                </li>
+            </ul>
+
+        </div>
+    </div>
     <button type="button"
             class="umb-node-preview-add"
             id="{{model.alias}}"

--- a/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
+++ b/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
@@ -300,8 +300,12 @@
     <Compile Include="Core\Trees\TreeCollectionBuilderExtensions.cs" />
     <Compile Include="Core\Xml\UmbracoXPathPathSyntaxParser.cs" />
     <Compile Include="DataEditors\ConfigurationEditor\ConfigurationEditorUtility.cs" />
+    <Compile Include="DataEditors\ContentBlocks\ContentBlockPreviewView.cs" />
+    <Compile Include="DataEditors\ContentBlocks\ContentBlocksViewHelper.cs" />
     <Compile Include="DataEditors\ContentBlocks\ContentBlocksDisplayModeConfigurationField.cs" />
+    <Compile Include="DataEditors\ContentBlocks\ContentBlocksApiController.cs" />
     <Compile Include="Composing\ContentmentListItemCollectionBuilder.cs" />
+    <Compile Include="DataEditors\ContentBlocks\ContentBlockPreviewModel.cs" />
     <Compile Include="DataEditors\ContentPicker\ContentPickerDataEditor.cs" />
     <Compile Include="DataEditors\DataList\DataSources\UmbracoContentDataListSource.cs" />
     <Compile Include="DataEditors\DataList\IDataListSourceValueConverter.cs" />
@@ -387,6 +391,7 @@
     <None Include="DataEditors\CheckboxList\README.md" />
     <None Include="DataEditors\CodeEditor\README.md" />
     <None Include="DataEditors\ConfigurationEditor\README.md" />
+    <None Include="DataEditors\ContentBlocks\ContentBlockPreview.cshtml" />
     <None Include="DataEditors\DataList\README.md" />
     <None Include="DataEditors\DataTable\README.md" />
     <None Include="DataEditors\DropdownList\README.md" />
@@ -456,6 +461,9 @@
     <Content Include="Web\UI\App_Plugins\Contentment\lang\en.xml" />
     <Content Include="Web\UI\backoffice-ui-shim.css" />
     <Content Include="Web\UI\backoffice.js" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Web\UI\App_Plugins\Contentment\render\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Umbraco.SqlServerCE.4.0.0.1\build\Umbraco.SqlServerCE.targets" Condition="Exists('..\packages\Umbraco.SqlServerCE.4.0.0.1\build\Umbraco.SqlServerCE.targets')" />


### PR DESCRIPTION
### Description

Adds rich preview feature for Content Blocks editor.  Using a Razor partial view template to render the markup, with the model based on the current page (`IPublishedContent`) and content block (`IPublishedElement`).

The Razor partial view would need to inherit from the following...

```cshtml
@inherits ContentBlockPreviewView
```

Which is shorthand for...
```cshtml
@inherits ContentBlockPreviewView<IPublishedContent, IPublishedElement>
```

...and that means, for extra syntax sugar, you can use your ModelsBuilder types, e.g...

```cshtml
@inherits ContentBlockPreviewView<MyContentPageModel, MyElementBlockModel>
```

Accessing the page and element is like so...

```cshtml
<h5>@Model.Content.Name</h5>
<p>@Model.Element.Value("somePropertyAlias")</p>
```

### Types of changes

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [x] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
