### PR TITLE
Restrict when `ContentmentComponent` should be added

### DIFF
--- a/src/Umbraco.Community.Contentment/Composing/ContentmentComponentComposer.cs
+++ b/src/Umbraco.Community.Contentment/Composing/ContentmentComponentComposer.cs
@@ -22,11 +22,14 @@ namespace Umbraco.Community.Contentment.Composing
             ;
 
             composition.RegisterUnique<ConfigurationEditorUtility>();
+            if (composition.RuntimeState.Level >= RuntimeLevel.Upgrade)
+            {
+                composition
+                   .Components()
+                       .Append<ContentmentComponent>()
+               ;
+            }
 
-            composition
-                .Components()
-                    .Append<ContentmentComponent>()
-            ;
         }
     }
 }


### PR DESCRIPTION
### Description

`ContentmentComponent` should only be added when the site is either running or upgrading.

### Related Issues?

A possible fix for issue #34

### Types of changes

- [ ] Documentation change
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
