### PR TITLE
ItemPicker - when overlay is closed, focus state is restored

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/ItemPicker/item-picker.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/ItemPicker/item-picker.js
@@ -6,9 +6,10 @@
 angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.ItemPicker.Controller", [
     "$scope",
     "editorService",
+    "focusService",
     "localizationService",
     "overlayService",
-    function ($scope, editorService, localizationService, overlayService) {
+    function ($scope, editorService, focusService, localizationService, overlayService) {
 
         // console.log("item-picker.model", $scope.model);
 
@@ -87,6 +88,8 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
 
         function add() {
 
+            focusService.rememberFocus();
+
             var items = Object.toBoolean(config.allowDuplicates)
                 ? config.items
                 : config.items.filter(x => vm.items.some(y => x.value === y.value) === false);
@@ -115,17 +118,22 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
                         vm.allowAdd = false;
                     }
 
-                    setDirty();
-
                     editorService.close();
+
+                    setDirty();
+                    setFocus();
                 },
                 close: function () {
                     editorService.close();
+                    setFocus();
                 }
             });
         };
 
         function remove($index) {
+
+            focusService.rememberFocus();
+
             if (config.confirmRemoval === true) {
                 var keys = ["contentment_removeItemMessage", "general_remove", "general_cancel", "contentment_removeItemButton"];
                 localizationService.localizeMany(keys).then(function (data) {
@@ -141,6 +149,7 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
                         },
                         close: function () {
                             overlayService.close();
+                            setFocus();
                         }
                     });
                 });
@@ -165,6 +174,13 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
         function setDirty() {
             if ($scope.propertyForm) {
                 $scope.propertyForm.$setDirty();
+            }
+        };
+
+        function setFocus() {
+            var lastKnownFocus = focusService.getLastKnownFocus();
+            if (lastKnownFocus) {
+                lastKnownFocus.focus();
             }
         };
 


### PR DESCRIPTION
> A small change, for part of the Accessibility review #41.

@BatJan - would you be able to advice if this approach aligns with how this is being done in Umbraco? and/or if there is a better approach? _(Thank you in advance.)_

### Description

Uses Umbraco's `focusService` to remember the current focus state before the ItemPicker's overlay is opened.
Once the overlay is closed, the focus state is restored.

### Related Issues?

- #41 Accessibility review

### Types of changes

- [x] Bug fix _(non-breaking change which fixes an issue)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
