### PR TITLE
Data List: Preview when configuring the Data Type

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/ConfigurationEditor/configuration-editor.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/ConfigurationEditor/configuration-editor.js
@@ -6,11 +6,13 @@
 angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.ConfigurationEditor.Controller", [
     "$scope",
     "$interpolate",
+    "$timeout",
     "editorService",
+    "eventsService",
     "localizationService",
     "overlayService",
     "Umbraco.Community.Contentment.Services.DevMode",
-    function ($scope, $interpolate, editorService, localizationService, overlayService, devModeService) {
+    function ($scope, $interpolate, $timeout, editorService, eventsService, localizationService, overlayService, devModeService) {
 
         // console.log("config-editor.model", $scope.model);
 
@@ -102,6 +104,8 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
                 });
             }
 
+            // NOTE: Must wait, otherwise the preview may not be ready to receive the event.
+            $timeout(function () { emit(); }, 100);
         };
 
         function add() {
@@ -165,6 +169,10 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
                     editorService.close();
                 }
             });
+        };
+
+        function emit() {
+            eventsService.emit("contentment.config-editor.model", $scope.model);
         };
 
         function populate(item, $index, propertyName) {
@@ -232,6 +240,7 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
             if ($scope.propertyForm) {
                 $scope.propertyForm.$setDirty();
             }
+            emit();
         };
 
         init();

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataListApiController.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataListApiController.cs
@@ -1,0 +1,45 @@
+﻿/* Copyright © 2020 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+using Newtonsoft.Json.Linq;
+using Umbraco.Core.PropertyEditors;
+using Umbraco.Web.Editors;
+using Umbraco.Web.Mvc;
+using Umbraco.Web.WebApi;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    [PluginController(Constants.Internals.PluginControllerName), IsBackOffice]
+    public sealed class DataListApiController : UmbracoAuthorizedJsonController
+    {
+        private readonly PropertyEditorCollection _propertyEditors;
+
+        public DataListApiController(PropertyEditorCollection propertyEditors)
+        {
+            _propertyEditors = propertyEditors;
+        }
+
+        [HttpPost]
+        public HttpResponseMessage GetPreview([FromBody] JObject data)
+        {
+            var config = data.ToObject<Dictionary<string, object>>();
+
+            if (_propertyEditors.TryGet(DataListDataEditor.DataEditorAlias, out var propertyEditor) == true)
+            {
+                var configurationEditor = propertyEditor.GetConfigurationEditor();
+                var valueEditorConfig = configurationEditor.ToValueEditor(config);
+                var valueEditor = propertyEditor.GetValueEditor(config);
+
+                return Request.CreateResponse(HttpStatusCode.OK, new { config = valueEditorConfig, view = valueEditor.View });
+            }
+
+            return Request.CreateResponse(HttpStatusCode.NotFound);
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataListConfigurationEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataListConfigurationEditor.cs
@@ -60,6 +60,12 @@ namespace Umbraco.Community.Contentment.DataEditors
                     { Constants.Conventions.ConfigurationFieldAliases.AddButtonLabelKey, "contentment_configureListEditor" },
                     { Constants.Conventions.ConfigurationFieldAliases.Items, listEditors }
                 });
+
+            Fields.Add(
+                "preview",
+                "Preview",
+                null,
+                IOHelper.ResolveUrl(DataListDataEditor.DataEditorPreviewViewPath));
         }
 
         public override IDictionary<string, object> ToValueEditor(object configuration)

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataListDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataListDataEditor.cs
@@ -15,6 +15,7 @@ namespace Umbraco.Community.Contentment.DataEditors
         internal const string DataEditorAlias = Constants.Internals.DataEditorAliasPrefix + "DataList";
         internal const string DataEditorName = Constants.Internals.DataEditorNamePrefix + "Data List";
         internal const string DataEditorViewPath = Constants.Internals.EditorsPathRoot + "_empty.html";
+        internal const string DataEditorPreviewViewPath = Constants.Internals.EditorsPathRoot + "data-list.preview.html";
         internal const string DataEditorIcon = "icon-fa fa-list-ul";
 
         private readonly ConfigurationEditorUtility _utility;

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/data-list.preview.css
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/data-list.preview.css
@@ -1,0 +1,17 @@
+﻿/* Copyright © 2021 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/* "Well" container - limiting the width, to match property width limit. */
+.contentment .well.well--limit-width {
+    max-width: 760px;
+}
+
+.contentment .well.well-small.well--limit-width {
+    max-width: 780px;
+}
+
+.contentment .well.well-large.well--limit-width {
+    max-width: 760px;
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/data-list.preview.html
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/data-list.preview.html
@@ -1,0 +1,59 @@
+﻿<!-- Copyright © 2020 Lee Kelleher.
+   - This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+<div class="contentment" ng-controller="Umbraco.Community.Contentment.DataEditors.DataList.Preview.Controller as vm">
+    <div ng-switch="vm.state">
+        <div ng-switch-default class="well well-small well--limit-width">
+            <localize key="contentment_configurePreviewInit">Please select and configure a data source and list editor.</localize>
+        </div>
+        <div ng-switch-when="dataSourceConfigured" class="well well-small well--limit-width">
+            <localize key="contentment_configurePreviewListEditor">Please select and configure a list editor.</localize>
+        </div>
+        <div ng-switch-when="listEditorConfigured" class="well well-small well--limit-width">
+            <localize key="contentment_configurePreviewDataSource">Please select and configure a data source.</localize>
+        </div>
+        <div ng-switch-when="loading">
+            <umb-load-indicator></umb-load-indicator>
+        </div>
+        <div ng-switch-when="loaded">
+
+            <umb-tabs-nav ng-if="vm.tabs"
+                          tabs="vm.tabs"
+                          on-tab-change="vm.changeTab(tab)">
+            </umb-tabs-nav>
+
+            <div ng-switch="vm.activeTab">
+                <div ng-switch-when="listEditor" ng-if="vm.property">
+                    <umb-property-editor model="vm.property"></umb-property-editor>
+                </div>
+                <div ng-switch-when="dataSource" ng-if="vm.property.config.items.length > 0">
+                    <div class="umb-table" style="background-color:#f6f4f4;">
+                        <div class="umb-table-head">
+                            <div class="umb-table-row">
+                                <div class="umb-table-cell"></div>
+                                <div class="umb-table-cell umb-table__name">Name</div>
+                                <div class="umb-table-cell">Value</div>
+                                <div class="umb-table-cell">Description</div>
+                                <div class="umb-table-cell">Enabled</div>
+                            </div>
+                        </div>
+                        <div class="umb-table-body">
+                            <div class="umb-table-row"
+                                 ng-class="{ '-light': item.disabled }"
+                                 ng-repeat="item in vm.property.config.items">
+                                <div class="umb-table-cell"><i class="umb-table-body__icon" ng-class="item.icon"></i></div>
+                                <div class="umb-table-cell umb-table__name"><span ng-bind="item.name"></span></div>
+                                <div class="umb-table-cell"><span ng-bind="item.value"></span></div>
+                                <div class="umb-table-cell"><span ng-bind="item.description"></span></div>
+                                <div class="umb-table-cell"><i class="icon" ng-class="{ 'icon-check': !item.disabled , 'icon-wrong': item.disabled }"></i></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</div>

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/data-list.preview.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/data-list.preview.js
@@ -1,0 +1,87 @@
+﻿/* Copyright © 2020 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.DataList.Preview.Controller", [
+    "$scope",
+    "$http",
+    "eventsService",
+    "umbRequestHelper",
+    function ($scope, $http, eventsService, umbRequestHelper) {
+
+        //console.log("data-list.preview.model", $scope.model);
+
+        var config = Object.assign({}, $scope.model.config);
+        var vm = this;
+
+        function init() {
+
+            vm.property = {};
+            vm.state = "loading";
+
+            vm.tabs = [{
+                label: "Editor preview",
+                alias: "listEditor",
+                active: false,
+            }, {
+                label: "Data source items",
+                alias: "dataSource",
+                active: false,
+            }];
+
+            // set the first tab to active
+            vm.tabs[0].active = true;
+            vm.activeTab = vm.tabs[0].alias;
+
+            vm.changeTab = function (tab) {
+                vm.tabs.forEach(function (x) { x.active = false; });
+                vm.activeTab = tab.alias;
+                tab.active = true;
+            };
+
+            var events = [];
+
+            events.push(eventsService.on("contentment.config-editor.model", function (event, args) {
+                config[args.alias] = args.value;
+                fetch();
+            }));
+
+            $scope.$on("$destroy", function () {
+                for (var event in events) {
+                    eventsService.unsubscribe(events[event]);
+                }
+            });
+
+        };
+
+        function fetch() {
+            if (_.isEmpty(config.dataSource) === false && _.isEmpty(config.listEditor) === false) {
+
+                vm.state = "loading";
+                vm.property = null;
+
+                umbRequestHelper.resourcePromise(
+                    $http.post("backoffice/Contentment/DataListApi/GetPreview", config),
+                    "Failed to retrieve data list preview.")
+                    .then(function (result) {
+
+                        vm.property = result;
+                        vm.state = "loaded";
+
+                    });
+            }
+            else if (_.isEmpty(config.dataSource) === false) {
+                vm.state = "dataSourceConfigured";
+            }
+            else if (_.isEmpty(config.listEditor) === false) {
+                vm.state = "listEditorConfigured";
+            }
+            else {
+                vm.state = "init";
+            }
+        };
+
+        init();
+    }
+]);

--- a/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
+++ b/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
@@ -312,6 +312,7 @@
     <Compile Include="DataEditors\ContentBlocks\DisplayModes\StackDisplayMode.cs" />
     <Compile Include="DataEditors\ContentBlocks\IContentBlocksDisplayMode.cs" />
     <Compile Include="DataEditors\ContentPicker\ContentPickerDataEditor.cs" />
+    <Compile Include="DataEditors\DataList\DataListApiController.cs" />
     <Compile Include="DataEditors\DataList\DataSources\UmbracoContentDataListSource.cs" />
     <Compile Include="DataEditors\DataList\IDataListSourceValueConverter.cs" />
     <Compile Include="DataEditors\DataList\DataSources\JsonDataListSource.cs" />
@@ -433,6 +434,9 @@
     <Content Include="DataEditors\ContentBlocks\content-blocks.blueprint.html" />
     <Content Include="DataEditors\ContentPicker\content-source.html" />
     <Content Include="DataEditors\ContentPicker\content-source.js" />
+    <Content Include="DataEditors\DataList\data-list.preview.css" />
+    <Content Include="DataEditors\DataList\data-list.preview.html" />
+    <Content Include="DataEditors\DataList\data-list.preview.js" />
     <Content Include="DataEditors\DataTable\data-table.html" />
     <Content Include="DataEditors\DataTable\data-table.js" />
     <Content Include="DataEditors\DropdownList\dropdown-list.html" />

--- a/src/Umbraco.Community.Contentment/Web/UI/App_Plugins/Contentment/lang/da.xml
+++ b/src/Umbraco.Community.Contentment/Web/UI/App_Plugins/Contentment/lang/da.xml
@@ -24,6 +24,9 @@
         <!-- Data List -->
         <key alias="configureDataSource">Vælg og konfigurer en datakilde</key>
         <key alias="configureListEditor">Vælg og konfigurer en liste</key>
+        <key alias="configurePreviewInit">Vælg og konfigurer en datakilde og en listeeditor, tak.</key>
+        <key alias="configurePreviewDataSource">Vælg og konfigurer en datakilde, tak.</key>
+        <key alias="configurePreviewListEditor">Vælg og konfigurer en liste, tak.</key>
 
     </area>
 </language>

--- a/src/Umbraco.Community.Contentment/Web/UI/App_Plugins/Contentment/lang/en.xml
+++ b/src/Umbraco.Community.Contentment/Web/UI/App_Plugins/Contentment/lang/en.xml
@@ -24,6 +24,9 @@
         <!-- Data List -->
         <key alias="configureDataSource">Select and configure a data source</key>
         <key alias="configureListEditor">Select and configure a list editor</key>
+        <key alias="configurePreviewInit">Please select and configure a data source and list editor.</key>
+        <key alias="configurePreviewDataSource">Please select and configure a data source.</key>
+        <key alias="configurePreviewListEditor">Please select and configure a list editor.</key>
 
         <key alias="tagsType">Type to select an item...</key>
     </area>

--- a/src/Umbraco.Community.Contentment/Web/UI/App_Plugins/Contentment/lang/pt-br.xml
+++ b/src/Umbraco.Community.Contentment/Web/UI/App_Plugins/Contentment/lang/pt-br.xml
@@ -24,6 +24,9 @@
         <!-- Data List -->
         <key alias="configureDataSource">Selecionar e configurar a origem dos dados</key>
         <key alias="configureListEditor">Selecionar e configurar o editor de lista</key>
+        <key alias="configurePreviewInit">Selecionar e configurar a origem dos dados e o editor de lista, por favor.</key>
+        <key alias="configurePreviewDataSource">Selecionar e configurar a origem dos dados, por favor.</key>
+        <key alias="configurePreviewListEditor">Selecionar e configurar o editor de lista, por favor.</key>
 
     </area>
 </language>


### PR DESCRIPTION
### Description

I've been asked a few times whether it would be possible to display a preview of the Data List editor whilst it is being configured in the Data Type itself.

Once the Data Source and List Editor fields are configured, a preview panel will appear at the bottom of the Data Type, displaying the rendered list-editor and a table of the data-source items.

![Screenshot 2020-11-20 152323](https://user-images.githubusercontent.com/209066/99831422-f014aa00-2b56-11eb-9bf3-0b3c9b3d0726.png)

### Types of changes

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [x] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
