### PR TITLE
Replaced angular.(to|From)Json with Utilities.

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/_/_dev-mode.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/_/_dev-mode.js
@@ -11,10 +11,7 @@ angular.module("umbraco.services").factory("Umbraco.Community.Contentment.Servic
             editValue: function (model, callback) {
                 editorService.open({
                     title: "Edit raw value",
-                    value: angular.toJson(model.value, true), // TODO: Replace AngularJS dependency. [LK:2020-03-02]
-                    // https://github.com/leekelleher/umbraco-contentment/issues/38
-                    // https://trello.com/c/UTjBLFQd/17-replace-instances-of-angulartojson
-                    // or wait for the Utility helper in v8.7.0? https://github.com/umbraco/Umbraco-CMS/blob/release-8.7.0/src/Umbraco.Web.UI.Client/src/utilities.js#L89
+                    value: Utilities.toJson(model.value, true),                    
                     ace: {
                         showGutter: true,
                         useWrapMode: true,
@@ -35,11 +32,7 @@ angular.module("umbraco.services").factory("Umbraco.Community.Contentment.Servic
                     size: "medium",
                     submit: function (value) {
 
-                        model.value = angular.fromJson(value); // TODO: Replace AngularJS dependency. [LK:2020-03-02]
-                        // https://github.com/leekelleher/umbraco-contentment/issues/38
-                        // https://trello.com/c/uPQwJmDQ/9-replace-instances-of-angularfromjson
-                        // https://github.com/umbraco/Umbraco-CMS/pull/7952
-
+                        model.value = Utilities.fromJson(value);
                         if (callback) {
                             callback();
                         }

--- a/src/Umbraco.Community.Contentment/DataEditors/_/_dev-mode.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/_/_dev-mode.js
@@ -11,7 +11,7 @@ angular.module("umbraco.services").factory("Umbraco.Community.Contentment.Servic
             editValue: function (model, callback) {
                 editorService.open({
                     title: "Edit raw value",
-                    value: Utilities.toJson(model.value, true),                    
+                    value: Utilities.toJson(model.value, true),
                     ace: {
                         showGutter: true,
                         useWrapMode: true,
@@ -33,6 +33,7 @@ angular.module("umbraco.services").factory("Umbraco.Community.Contentment.Servic
                     submit: function (value) {
 
                         model.value = Utilities.fromJson(value);
+
                         if (callback) {
                             callback();
                         }


### PR DESCRIPTION
### Description

Removing the use of `angular.ToJson` and `FromJson`. This is a breaking change as it requires version 8.7+ of Umbraco.

Tested on v8.9.1

### Related Issues?

#38 

### Types of changes

- [ ] Documentation change
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [x] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
