### PR TITLE
Adds Telemetry

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -32,6 +32,9 @@ Let's take a look inside...
 - [Render Macro](../docs/editors/render-macro.md) - a read-only label dynamically generated from an Umbraco Macro.
 - [Text Input](../docs/editors/text-input.md) - a textstring editor, configurable with HTML5 options.
 
+##### Telemetry
+
+Information about the [telemetry feature](../docs/telemetry.md).
 
 #### Releases
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,3 +31,8 @@ If you are unfamiliar with how to do this, then please refer to documentation, g
 - [Our Umbraco - Getting Started - Data](https://our.umbraco.com/Documentation/Getting-Started/Data/)
 - [Our Umbraco - Getting Started - Data - Defining content](https://our.umbraco.com/Documentation/Getting-Started/Data/Defining-content/)
 - [Our Umbraco - Getting Started - Data - Customizing Data Types](https://our.umbraco.com/Documentation/Getting-Started/Data/Data-Types/)
+
+#### Telemetry
+
+Information about Contentment's [telemetry feature](../docs/telemetry.md).
+

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,50 @@
+<img src="assets/img/logo.png" alt="Contentment for Umbraco logo" title="A state of Umbraco happiness." height="130" align="right">
+
+## Contentment for Umbraco
+
+### Telemetry
+
+Since version 1.2.0, by default, the package has been collecting telemetry data. This provides me with insights to which of the editors are being used, so that I can make informed decisions on how to focus my future development efforts.
+
+When a Data Type is saved in the CMS backoffice, minimal data about the property-editor is collected and a request is sent to my web-server. The data is sent anonymously, no personal or sensitive data is collected.
+
+Here is an example of the JSON data that is sent.
+
+```json
+{
+    dataType = "4E7D6B3A-F959-42E4-921E-081BC0E9E7EE",
+    editorAlias = "DataList",
+    umbracoId = "0403E47E-EFE7-4CF2-8E97-148681DAFC10",
+    umbracoVersion = "8.6.6",
+    contentmentVersion = "1.2.0",
+}
+```
+
+The JSON is then encoded as Base64, sent to my web-server, where it is then decoded and stored in a database.
+
+**A note about the `umbracoId` value.** Currently, (for v1.x), the value is a GUID, derived from an MD5 hash of the `Server.MachineName`. _(Note, since I encrypt the machine name, it is never known to me)._ Once I have increased the minimum Umbraco dependency (for Contentment v2.x) to beyond v8.10, I will use the same GUID as Umbraco does for their own telemetry purposes.
+
+For information about the data and analysis, please go to: <https://leekelleher.com/umbraco/contentment/telemetry/>
+
+
+#### Disable telemetry feature
+
+If you would prefer to disable the telemetry feature completely, you can use this code snippet to disable it.
+
+```csharp
+using Umbraco.Core.Composing;
+
+namespace Our.Umbraco.Web
+{
+    public class DisableContentmentTreeComposer : IUserComposer
+    {
+        public void Compose(Composition composition)
+        {
+            composition.DisableContentmentTree();
+        }
+    }
+}
+```
+
+If you already have your own composer class, you can add the `composition.DisableContentmentTelemetry();` line to it.
+

--- a/src/Umbraco.Community.Contentment.sln
+++ b/src/Umbraco.Community.Contentment.sln
@@ -35,6 +35,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentation", "{9C956438-0434-40DD-BBA0-7F837E8FF1C8}"
 	ProjectSection(SolutionItems) = preProject
 		..\docs\README.md = ..\docs\README.md
+		..\docs\telemetry.md = ..\docs\telemetry.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Editors", "Editors", "{A5294B30-2ED5-4BBA-A2DE-A07103DAE78F}"

--- a/src/Umbraco.Community.Contentment/Composing/ContentmentComponent.cs
+++ b/src/Umbraco.Community.Contentment/Composing/ContentmentComponent.cs
@@ -55,7 +55,8 @@ namespace Umbraco.Community.Contentment.Composing
                 umbracoPlugins.Add(Constants.Internals.ProjectAlias, new
                 {
                     name = Constants.Internals.ProjectName,
-                    version = Configuration.ContentmentVersion.SemanticVersion.ToSemanticString()
+                    version = Configuration.ContentmentVersion.SemanticVersion.ToSemanticString(),
+                    telemetry = Telemetry.ContentmentTelemetryComponent.Enabled,
                 });
             }
         }

--- a/src/Umbraco.Community.Contentment/Composing/ContentmentComposer.cs
+++ b/src/Umbraco.Community.Contentment/Composing/ContentmentComposer.cs
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 using Umbraco.Community.Contentment.DataEditors;
+using Umbraco.Community.Contentment.Telemetry;
 using Umbraco.Core;
 using Umbraco.Core.Composing;
 using Umbraco.Web.Runtime;
@@ -28,6 +29,7 @@ namespace Umbraco.Community.Contentment.Composing
                 composition
                     .Components()
                         .Append<ContentmentComponent>()
+                        .Append<ContentmentTelemetryComponent>()
                 ;
             }
 

--- a/src/Umbraco.Community.Contentment/Telemetry/CompositionExtensions.cs
+++ b/src/Umbraco.Community.Contentment/Telemetry/CompositionExtensions.cs
@@ -1,0 +1,34 @@
+﻿/* Copyright © 2021 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using Umbraco.Community.Contentment.Telemetry;
+
+// NOTE: This extension method class is deliberately using the Umbraco namespace,
+// as to reduce namespace imports and ease the developer experience. [LK]
+namespace Umbraco.Core.Composing
+{
+    public static partial class CompositionExtensions
+    {
+        public static Composition EnableContentmentTelemetry(this Composition composition)
+        {
+            composition
+                .Components()
+                    .Append<ContentmentTelemetryComponent>()
+            ;
+
+            return composition;
+        }
+
+        public static Composition DisableContentmentTelemetry(this Composition composition)
+        {
+            composition
+                .Components()
+                    .Remove<ContentmentTelemetryComponent>()
+            ;
+
+            return composition;
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/Telemetry/ContentmentTelemetryComponent.cs
+++ b/src/Umbraco.Community.Contentment/Telemetry/ContentmentTelemetryComponent.cs
@@ -1,0 +1,86 @@
+﻿/* Copyright © 2021 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System;
+using System.Net;
+using System.Net.Mime;
+using System.Text;
+using System.Threading.Tasks;
+using ClientDependency.Core;
+using Newtonsoft.Json;
+using Umbraco.Community.Contentment.Configuration;
+using Umbraco.Core;
+using Umbraco.Core.Composing;
+using Umbraco.Core.Configuration;
+using Umbraco.Core.Events;
+using Umbraco.Core.Models;
+using Umbraco.Core.Services;
+using Umbraco.Core.Services.Implement;
+using Umbraco.Web;
+
+namespace Umbraco.Community.Contentment.Telemetry
+{
+    internal sealed class ContentmentTelemetryComponent : IComponent
+    {
+        internal static bool Enabled { get; private set; }
+
+        private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+
+        public ContentmentTelemetryComponent(IUmbracoContextAccessor umbracoContextAccessor)
+        {
+            _umbracoContextAccessor = umbracoContextAccessor;
+        }
+
+        public void Initialize()
+        {
+            Enabled = true;
+            DataTypeService.Saved += DataTypeService_Saved;
+        }
+
+        public void Terminate()
+        {
+            Enabled = false;
+            DataTypeService.Saved -= DataTypeService_Saved;
+        }
+
+        private void DataTypeService_Saved(IDataTypeService sender, SaveEventArgs<IDataType> e)
+        {
+            foreach (var entity in e.SavedEntities)
+            {
+                if (entity.EditorAlias.InvariantStartsWith(Constants.Internals.DataEditorAliasPrefix) == true)
+                {
+                    try
+                    {
+                        // TODO: [LK] After v8.10.0 bump, switch this to use `IUmbracoSettingsSection.BackOffice.Id`.
+                        var umbracoId = _umbracoContextAccessor.UmbracoContext?.HttpContext?.Server != null
+                            ? new Guid(_umbracoContextAccessor.UmbracoContext.HttpContext.Server.MachineName.GenerateMd5())
+                            : Guid.Empty;
+
+                        // No identifiable details, just a quick call home.
+                        var data = new
+                        {
+                            dataType = entity.Key,
+                            editorAlias = entity.EditorAlias.Substring(Constants.Internals.DataEditorAliasPrefix.Length),
+                            umbracoId = umbracoId,
+                            umbracoVersion = UmbracoVersion.SemanticVersion.ToString(),
+                            contentmentVersion = ContentmentVersion.SemanticVersion.ToString(),
+                        };
+
+                        using (var client = new WebClient())
+                        {
+                            var address = new Uri("https://leekelleher.com/umbraco/contentment/telemetry/");
+                            var json = JsonConvert.SerializeObject(data, Formatting.Indented);
+                            var payload = Convert.ToBase64String(Encoding.UTF8.GetBytes(json));
+
+                            client.Headers.Add("Content-Type", MediaTypeNames.Text.Plain);
+                            Task.Run(() => client.UploadStringAsync(address, payload));
+                        }
+                    }
+                    catch { /* ¯\_(ツ)_/¯ */ }
+                }
+            }
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
+++ b/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
@@ -296,6 +296,8 @@
   <ItemGroup>
     <Compile Include="Composing\ContentmentComposer.cs" />
     <Compile Include="Composing\ContentmentCompositionExtensions.cs" />
+    <Compile Include="Telemetry\CompositionExtensions.cs" />
+    <Compile Include="Telemetry\ContentmentTelemetryComponent.cs" />
     <Compile Include="Configuration\ContentmentVersion.cs" />
     <Compile Include="Core\Trees\TreeCollectionBuilderExtensions.cs" />
     <Compile Include="Core\Xml\UmbracoXPathPathSyntaxParser.cs" />

--- a/src/Umbraco.Community.Contentment/Web/UI/App_Plugins/Contentment/backoffice/contentment/index.html
+++ b/src/Umbraco.Community.Contentment/Web/UI/App_Plugins/Contentment/backoffice/contentment/index.html
@@ -88,18 +88,42 @@
                     <umb-box>
                         <umb-box-header title="Feature options"></umb-box-header>
                         <umb-box-content>
-                            <h5 class="mt0">Tree dashboard</h5>
-                            <p>If you would like to remove this page and tree item from the Settings section, you can use the following code snippet to do so.</p>
-                            <div class="umb-readonlyvalue">
-                                <details class="well well-small">
-                                    <summary><strong>Code snippet to disable Contentment tree dashboard</strong></summary>
-                                    <div class="mt3">
-                                        <p>Copy the C# class below. You can either save this to your <code>~/App_Code/</code> folder, or add it to your own code library.</p>
-                                    </div>
-                                    <umb-code-snippet language="vm.csharp">{{vm.disableTreeCode}}</umb-code-snippet>
-                                    <p>If you are already using a composer class, you can add the <code>composition.DisableContentmentTree();</code> line to it.</p>
-                                </details>
+
+                            <div>
+                                <h5 class="mt0">Tree dashboard</h5>
+                                <p>If you would like to remove this page and tree item from the Settings section, you can use the following code snippet to do so.</p>
+                                <div class="umb-readonlyvalue">
+                                    <details class="well well-small">
+                                        <summary><strong>Code snippet to disable Contentment tree dashboard</strong></summary>
+                                        <div class="mt3">
+                                            <p>Copy the C# class below. You can either save this to your <code>~/App_Code/</code> folder, or add it to your own code library.</p>
+                                        </div>
+                                        <umb-code-snippet language="vm.csharp">{{vm.disableTreeCode}}</umb-code-snippet>
+                                        <p>If you are already using a composer class, you can add the <code>composition.DisableContentmentTree();</code> line to it.</p>
+                                    </details>
+                                </div>
                             </div>
+
+                            <div ng-if="vm.telemetryEnabled === true">
+                                <h5>Telemetry</h5>
+                                <p>By default, the package sends telemetry data about which property-editors are being used (from Contentment only). For more details about the data being captured and transparency on the analysis, please visit <a href="https://leekelleher.com/umbraco/contentment/telemetry/" target="_blank" rel="noopener"><strong>leekelleher.com/umbraco/contentment/telemetry</strong></a>.</p>
+                                <p>If you would prefer to opt-out and disable the telemetry feature, you can use the following code snippet to do so.</p>
+                                <div class="umb-readonlyvalue">
+                                    <details class="well well-small">
+                                        <summary><strong>Code snippet to disable Contentment telemetry</strong></summary>
+                                        <div class="mt3">
+                                            <p>Copy the C# class below. You can either save this to your <code>~/App_Code/</code> folder, or add it to your own code library.</p>
+                                        </div>
+                                        <umb-code-snippet language="vm.csharp">{{vm.disableTelemetryCode}}</umb-code-snippet>
+                                        <p>If you are already using a composer class, you can add the <code>composition.DisableContentmentTelemetry();</code> line to it.</p>
+                                    </details>
+                                </div>
+                            </div>
+                            <div ng-if="vm.telemetryEnabled === false">
+                                <h5>Telemetry</h5>
+                                <p><em>The telemetry feature has been disabled.</em></p>
+                            </div>
+
                         </umb-box-content>
                     </umb-box>
 

--- a/src/Umbraco.Community.Contentment/Web/UI/backoffice.js
+++ b/src/Umbraco.Community.Contentment/Web/UI/backoffice.js
@@ -67,6 +67,19 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.Tree.Control
             };
 
             vm.csharp = "csharp";
+            vm.telemetryEnabled = config.telemetry === true;
+            vm.disableTelemetryCode = `using Umbraco.Core.Composing;
+
+namespace Our.Umbraco.Web
+{
+    public class DisableContentmentTelemetryComposer : IUserComposer
+    {
+        public void Compose(Composition composition)
+        {
+            composition.DisableContentmentTelemetry();
+        }
+    }
+}`;
             vm.disableTreeCode = `using Umbraco.Core.Composing;
 
 namespace Our.Umbraco.Web


### PR DESCRIPTION
### Description

When a DataType is saved, a request is sent to my web-server with minimal data about the property-editor used.

An example of the JSON payload...

    {
        dataType = "4E7D6B3A-F959-42E4-921E-081BC0E9E7EE",
        editorAlias = "DataList",
        umbracoId = "0403E47E-EFE7-4CF2-8E97-148681DAFC10",
        umbracoVersion = "8.6.6",
        contentmentVersion = "1.2.0",
    }

The JSON is then encoded as Base64, (for transfer purposes), then decoded on my web-server and stored in a database, (currently using SQLite, will change if/when the volume of stats increases).

The `umbracoId` is currently (for v1.x) using a GUID of an MD5 hash of the `Server.MachineName`. This is only until I can use the new instance GUID introduced in Umbraco v8.10 for their own telemetry purposes. I needed to find a unique-ish value for an Umbraco instance. I appreciate that multiple Umbraco instances can be on the same machine, but this was a compromise I've gone with until Contentment v2.x, when I can increase the minimum dependency on Umbraco beyond v8.10+.

Further background information and analysis is available at: <https://leekelleher.com/umbraco/contentment/telemetry/>

### Types of changes

- [x] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [x] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
