### PR TITLE
Data List: Tags list editor

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/Tags/TagsDataListEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/Tags/TagsDataListEditor.cs
@@ -1,0 +1,43 @@
+﻿/* Copyright © 2021 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System.Collections.Generic;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    internal sealed class TagsDataListEditor : IDataListEditor
+    {
+        internal const string DataEditorViewPath = Constants.Internals.EditorsPathRoot + "tags.html";
+
+        public string Name => "Tags";
+
+        public string Description => "Select items from an Umbraco Tags-like interface.";
+
+        public string Icon => "icon-fa fa-tags";
+
+        public IEnumerable<ConfigurationField> Fields => new ConfigurationField[]
+        {
+            new ShowIconsConfigurationField(),
+            new ConfigurationField
+            {
+                Key ="confirmRemoval",
+                Name = "Confirm removals?",
+                Description = "Select to enable a confirmation prompt when removing an item.",
+                View = "boolean",
+            }
+        };
+
+        public Dictionary<string, object> DefaultValues => default;
+
+        public Dictionary<string, object> DefaultConfig => default;
+
+        public bool HasMultipleValues(Dictionary<string, object> config) => true;
+
+        public OverlaySize OverlaySize => OverlaySize.Small;
+
+        public string View => DataEditorViewPath;
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/Tags/tags.css
+++ b/src/Umbraco.Community.Contentment/DataEditors/Tags/tags.css
@@ -1,0 +1,20 @@
+﻿/* Copyright © 2021 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+.contentment .umb-tags .tag {
+    user-select: text;
+}
+
+    .contentment .umb-tags .tag .icon {
+        color: white !important;
+    }
+
+    .contentment .umb-tags .tag .btn-reset {
+        line-height: 14px;
+    }
+
+    .contentment .umb-tags .tag .icon-trash {
+        bottom: 0;
+    }

--- a/src/Umbraco.Community.Contentment/DataEditors/Tags/tags.html
+++ b/src/Umbraco.Community.Contentment/DataEditors/Tags/tags.html
@@ -1,0 +1,31 @@
+﻿<!-- Copyright © 2021 Lee Kelleher.
+   - This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+<div class="contentment" id="{{vm.uniqueId}}" ng-controller="Umbraco.Community.Contentment.DataEditors.Tags.Controller as vm">
+    <div class="umb-tags umb-tags-editor">
+        <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
+        <div ng-if="vm.loading === false">
+            <span class="label label-primary tag"
+                  tabindex="0"
+                  ng-keyup="vm.keyUp($event, $index)"
+                  ng-repeat="item in vm.items">
+                <i class="icon mr2" ng-class="item.icon" ng-if="vm.showIcons && item.icon"></i>
+                <span ng-bind="item.name"></span>
+                <button type="button" class="btn-reset" ng-click="vm.remove($index)">
+                    <i class="icon icon-trash"></i>
+                    <span class="sr-only">
+                        <localize key="general_remove">Remove</localize>
+                    </span>
+                </button>
+            </span>
+            <input type="text"
+                   id="{{model.alias}}"
+                   class="typeahead"
+                   localize="placeholder"
+                   placeholder="@contentment_tagsType"
+                   ng-keydown="vm.keyDown($event)" />
+        </div>
+    </div>
+</div>

--- a/src/Umbraco.Community.Contentment/DataEditors/Tags/tags.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/Tags/tags.js
@@ -1,0 +1,172 @@
+﻿/* Copyright © 2021 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.Tags.Controller", [
+    "$rootScope",
+    "$scope",
+    "$element",
+    "angularHelper",
+    "assetsService",
+    "localizationService",
+    "overlayService",
+    function ($rootScope, $scope, $element, angularHelper, assetsService, localizationService, overlayService) {
+
+        //console.log("tags.model", $scope.model);
+
+        var defaultConfig = {
+            confirmRemoval: 0,
+            defaultValue: [],
+            items: [],
+            showIcons: 0,
+        };
+        var config = Object.assign({}, defaultConfig, $scope.model.config);
+
+        var vm = this;
+
+        function init() {
+
+            $scope.model.value = $scope.model.value || config.defaultValue;
+
+            if (Array.isArray($scope.model.value) === false) {
+                $scope.model.value = [$scope.model.value];
+            }
+
+            config.confirmRemoval = Object.toBoolean(config.confirmRemoval);
+
+            vm.items = [];
+
+            vm.showIcons = Object.toBoolean(config.showIcons);
+
+            vm.uniqueId = [$scope.model.alias, $scope.model.dataTypeKey.substring(0, 8)].join("-");
+
+            vm.add = add;
+            vm.keyDown = keyDown;
+            vm.keyUp = keyUp;
+            vm.remove = remove;
+
+            vm.loading = true;
+
+            assetsService.loadJs("lib/typeahead.js/typeahead.bundle.min.js").then(function () {
+
+                $scope.model.value.forEach(function (v) {
+                    var item = config.items.find(x => x.value === v);
+                    if (item) {
+                        vm.items.push(Object.assign({}, item));
+                    }
+                });
+
+                vm.loading = false;
+
+                var engine = new Bloodhound({
+                    datumTokenizer: Bloodhound.tokenizers.obj.whitespace("value"),
+                    queryTokenizer: Bloodhound.tokenizers.whitespace,
+                    initialize: false,
+                    local: config.items.filter(x => !x.disabled), // TODO: Review the `filter`, is there a better way?
+                    identify: d => d.value,
+                });
+
+                engine.initialize().then(function () {
+
+                    var opts = {
+                        hint: true,
+                        highlight: true,
+                        minLength: 1
+                    };
+
+                    var sources = {
+                        display: "name",
+                        minLength: 0,
+                        source: function (q, sync) {
+                            if (q && q.length > 0) {
+                                engine.search(q, sync);
+                            } else {
+                                sync(engine.all());
+                            }
+                        }
+                    };
+
+                    vm.editor = $element.find("input.typeahead")
+                        .typeahead(opts, sources)
+                        .bind("typeahead:select", add)
+                        .bind("typeahead:autocomplete", add);
+                });
+
+            });
+
+        };
+
+        function add($event, item) {
+            angularHelper.safeApply($rootScope, function () {
+
+                vm.items.push(Object.assign({}, item));
+
+                $scope.model.value.push(item.value);
+
+                vm.editor.typeahead("val", "");
+
+                setDirty();
+            });
+        };
+
+        function keyDown($event) {
+            if ($event.keyCode == 13) {
+                var tt = vm.editor.data("ttTypeahead");
+                if (tt && tt.menu && tt.menu.isOpen() === true) {
+                    var selection = tt.menu.getActiveSelectable() || tt.menu.getTopSelectable();
+                    tt.menu.trigger("selectableClicked", selection);
+                    $event.preventDefault();
+                }
+            }
+        };
+
+        function keyUp($event, $index) {
+            console.log("keyUp", $event.keyCode, $index);
+            if ($event.keyCode === 8 || $event.keyCode === 46) {
+                remove($index);
+            }
+        };
+
+        function remove($index) {
+            if (config.confirmRemoval === true) {
+                var keys = ["contentment_removeItemMessage", "general_remove", "general_cancel", "contentment_removeItemButton"];
+                localizationService.localizeMany(keys).then(function (data) {
+                    overlayService.open({
+                        title: data[1],
+                        content: data[0],
+                        closeButtonLabel: data[2],
+                        submitButtonLabel: data[3],
+                        submitButtonStyle: "danger",
+                        submit: function () {
+                            removeItem($index);
+                            overlayService.close();
+                        },
+                        close: function () {
+                            overlayService.close();
+                        }
+                    });
+                });
+            } else {
+                removeItem($index);
+            }
+        };
+
+        function removeItem($index) {
+
+            vm.items.splice($index, 1);
+
+            $scope.model.value.splice($index, 1);
+
+            setDirty();
+        };
+
+        function setDirty() {
+            if ($scope.propertyForm) {
+                $scope.propertyForm.$setDirty();
+            }
+        };
+
+        init();
+    }
+]);

--- a/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
+++ b/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
@@ -322,6 +322,7 @@
     <Compile Include="DataEditors\NumberInput\NumberInputValueConverter.cs" />
     <Compile Include="DataEditors\NumberInput\NumberInputDataEditor.cs" />
     <Compile Include="DataEditors\NumberInput\NumberInputConfigurationEditor.cs" />
+    <Compile Include="DataEditors\Tags\TagsDataListEditor.cs" />
     <Compile Include="DataEditors\TemplatedList\TemplatedListDataListEditor.cs" />
     <Compile Include="DataEditors\TextInput\TextInputValueConverter.cs" />
     <Compile Include="DataEditors\_\ConfigurationFields\HtmlAttributesConfigurationField.cs" />
@@ -446,6 +447,9 @@
     <Content Include="DataEditors\NumberInput\number-input.html" />
     <None Include="DataEditors\ReadOnly\README.md" />
     <Content Include="DataEditors\NumberInput\number-input.js" />
+    <Content Include="DataEditors\Tags\tags.css" />
+    <Content Include="DataEditors\Tags\tags.html" />
+    <Content Include="DataEditors\Tags\tags.js" />
     <Content Include="DataEditors\TemplatedList\templated-list.html" />
     <Content Include="DataEditors\TemplatedList\templated-list.js" />
     <Content Include="DataEditors\TemplatedList\templated-list.css" />

--- a/src/Umbraco.Community.Contentment/Web/UI/App_Plugins/Contentment/lang/en.xml
+++ b/src/Umbraco.Community.Contentment/Web/UI/App_Plugins/Contentment/lang/en.xml
@@ -25,5 +25,6 @@
         <key alias="configureDataSource">Select and configure a data source</key>
         <key alias="configureListEditor">Select and configure a list editor</key>
 
+        <key alias="tagsType">Type to select an item...</key>
     </area>
 </language>


### PR DESCRIPTION
### Description

Adds a **Tags** editor for Data List.

Using a configured data source, with the UI closely following Umbraco's Tags property-editor.

![Screenshot 2021-03-09 151922](https://user-images.githubusercontent.com/209066/110494220-4a784d00-80eb-11eb-81cd-f6d60c97da82.png)

### Types of changes

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
