### PR TITLE
Data List: Buttons list editor

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/Buttons/ButtonsDataListEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/Buttons/ButtonsDataListEditor.cs
@@ -1,0 +1,89 @@
+﻿/* Copyright © 2020 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System.Collections.Generic;
+using Umbraco.Core;
+using Umbraco.Core.IO;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    public sealed class ButtonsDataListEditor : IDataListEditor
+    {
+        internal const string DataEditorViewPath = Constants.Internals.EditorsPathRoot + "buttons.html";
+
+        public string Name => "Buttons";
+
+        public string Description => "Select multiple values from a group of buttons.";
+
+        public string Icon => "icon-tab";
+
+        public IEnumerable<ConfigurationField> Fields => new ConfigurationField[]
+        {
+            new ConfigurationField
+            {
+                Key = "defaultIcon",
+                Name = "Default icon",
+                Description = "Select an icon to be displayed as the default icon, (for when no icon is available).",
+                View = IOHelper.ResolveUrl("~/umbraco/views/propertyeditors/listview/icon.prevalues.html"),
+            },
+            new ConfigurationField
+            {
+                Key = "size",
+                Name = "Size",
+                Description = "Select the button size. By default this is set to 'medium'.",
+                View = IOHelper.ResolveUrl(RadioButtonListDataListEditor.DataEditorViewPath),
+                Config = new Dictionary<string, object>
+                {
+                    { Constants.Conventions.ConfigurationFieldAliases.Items, new[]
+                        {
+                            new DataListItem { Name = "Small", Value = "s" },
+                            new DataListItem { Name = "Medium", Value = "m" },
+                            new DataListItem { Name = "Large", Value = "l" },
+                        }
+                    },
+                    { Constants.Conventions.ConfigurationFieldAliases.DefaultValue, "m" }
+                }
+            },
+            new ConfigurationField
+            {
+                Key = "hideIcon",
+                Name = "Hide icon?",
+                Description = "Select to hide the item's icon and only display the name.",
+                View = "boolean",
+            },
+            new ConfigurationField
+            {
+                Key = "hideName",
+                Name = "Hide name?",
+                Description = "Select to hide the item's name and only display the icon.<br><em>(Of course, don't hide both the name and icon)</em> 😉",
+                View = "boolean",
+            },
+            new ConfigurationField
+            {
+                Key = "enableMultiple",
+                Name = "Multiple selection?",
+                Description = "Select to enable picking multiple items.",
+                View = "boolean",
+            },
+        };
+
+        public Dictionary<string, object> DefaultValues => new Dictionary<string, object>
+        {
+            { "defaultIcon", Core.Constants.Icons.DefaultIcon },
+        };
+
+        public Dictionary<string, object> DefaultConfig => default;
+
+        public bool HasMultipleValues(Dictionary<string, object> config)
+        {
+            return config.TryGetValue("enableMultiple", out var tmp) && tmp.TryConvertTo<bool>().Result;
+        }
+
+        public OverlaySize OverlaySize => OverlaySize.Small;
+
+        public string View => DataEditorViewPath;
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/Buttons/ButtonsDataListEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/Buttons/ButtonsDataListEditor.cs
@@ -49,17 +49,22 @@ namespace Umbraco.Community.Contentment.DataEditors
             },
             new ConfigurationField
             {
-                Key = "hideIcon",
-                Name = "Hide icon?",
-                Description = "Select to hide the item's icon and only display the name.",
-                View = "boolean",
-            },
-            new ConfigurationField
-            {
-                Key = "hideName",
-                Name = "Hide name?",
-                Description = "Select to hide the item's name and only display the icon.<br><em>(Of course, don't hide both the name and icon)</em> 😉",
-                View = "boolean",
+                Key = "labelStyle",
+                Name = "Label style",
+                Description = "Select the style of the button's label.",
+                View = IOHelper.ResolveUrl(RadioButtonListDataListEditor.DataEditorViewPath),
+                Config = new Dictionary<string, object>
+                {
+                    { Constants.Conventions.ConfigurationFieldAliases.Items, new[]
+                        {
+                            new DataListItem { Name = "Icon and Text", Value = "both", Description = "Displays both the item's icon and name." },
+                            new DataListItem { Name = "Icon only", Value = "icon", Description = "Hides the item's name and only displays the icon." },
+                            new DataListItem { Name = "Text only", Value = "text", Description = "Hides the item's icon and only displays the name." },
+                        }
+                    },
+                    { Constants.Conventions.ConfigurationFieldAliases.DefaultValue, "both" },
+                    { ShowDescriptionsConfigurationField.ShowDescriptions, Constants.Values.True },
+                }
             },
             new ConfigurationField
             {
@@ -73,6 +78,7 @@ namespace Umbraco.Community.Contentment.DataEditors
         public Dictionary<string, object> DefaultValues => new Dictionary<string, object>
         {
             { "defaultIcon", Core.Constants.Icons.DefaultIcon },
+            { "labelStyle", "both" },
         };
 
         public Dictionary<string, object> DefaultConfig => default;

--- a/src/Umbraco.Community.Contentment/DataEditors/Buttons/buttons.css
+++ b/src/Umbraco.Community.Contentment/DataEditors/Buttons/buttons.css
@@ -1,0 +1,21 @@
+﻿/* Copyright © 2020 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+.contentment.lk-buttons .umb-button {
+    margin-bottom: 5px;
+}
+
+.contentment.lk-buttons .umb-button--selected .umb-button__button {
+    background-color: #f5c1bc;
+}
+
+.contentment.lk-buttons .umb-button__button {
+    padding-left: 20px;
+    padding-right: 20px;
+}
+
+    .contentment.lk-buttons .umb-button__button[disabled] {
+        opacity: 0.5;
+    }

--- a/src/Umbraco.Community.Contentment/DataEditors/Buttons/buttons.html
+++ b/src/Umbraco.Community.Contentment/DataEditors/Buttons/buttons.html
@@ -1,0 +1,17 @@
+﻿<!-- Copyright © 2020 Lee Kelleher.
+   - This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+<div class="contentment lk-buttons" ng-class="vm.uniqueId" ng-controller="Umbraco.Community.Contentment.DataEditors.Buttons.Controller as vm">
+    <umb-button type="button"
+                action="vm.select(item)"
+                size="{{vm.size}}"
+                ng-repeat="item in vm.items"
+                ng-class="{ 'umb-button--selected' : item.selected }"
+                label="{{vm.hideName === false ? item.name : null}}"
+                title="{{item.name}}"
+                icon="{{vm.hideIcon === false ? vm.iconExtras + (item.icon || vm.defaultIcon) : null}}"
+                disabled="item.disabled">
+    </umb-button>
+</div>

--- a/src/Umbraco.Community.Contentment/DataEditors/Buttons/buttons.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/Buttons/buttons.js
@@ -1,0 +1,93 @@
+﻿/* Copyright © 2020 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.Buttons.Controller", [
+    "$scope",
+    function ($scope) {
+
+        // console.log("buttons.model", $scope.model);
+
+        var defaultConfig = {
+            defaultIcon: "icon-science",
+            defaultValue: [],
+            items: [],
+            enableMultiple: 0,
+            hideIcon: 0,
+            hideName: 0,
+            size: "m",
+        };
+        var config = Object.assign({}, defaultConfig, $scope.model.config);
+
+        var vm = this;
+
+        function init() {
+            $scope.model.value = $scope.model.value || config.defaultValue;
+
+            if (Array.isArray($scope.model.value) === false) {
+                $scope.model.value = [$scope.model.value];
+            }
+
+            vm.multiple = Object.toBoolean(config.enableMultiple);
+
+            if (vm.multiple === false && $scope.model.value.length > 0) {
+                $scope.model.value.splice(1);
+            }
+
+            vm.items = config.items.slice();
+
+            vm.hideIcon = Object.toBoolean(config.hideIcon);
+            vm.hideName = Object.toBoolean(config.hideName);
+
+            vm.uniqueId = $scope.model.hasOwnProperty("dataTypeKey")
+                ? [$scope.model.alias, $scope.model.dataTypeKey.substring(0, 8)].join("-")
+                : $scope.model.alias;
+
+            var sizes = {
+                "s": "small",
+                "m": "medium",
+                "l": "large",
+            };
+
+            vm.size = config.size;
+
+            vm.defaultIcon = config.defaultIcon;
+            vm.iconExtras = sizes[config.size] + (vm.hideName === false ? " mr2 " : " mr0 ");
+
+            vm.items.forEach(function (item) {
+                item.selected = $scope.model.value.indexOf(item.value) > -1;
+            });
+
+            vm.select = select;
+        };
+
+        function select(item) {
+
+            item.selected = item.selected === false;
+            $scope.model.value = [];
+
+            vm.items.forEach(function (x) {
+
+                if (vm.multiple === false) {
+                    x.selected = x.value === item.value;
+                }
+
+                if (x.selected) {
+                    $scope.model.value.push(x.value);
+                }
+
+            });
+
+            setDirty();
+        };
+
+        function setDirty() {
+            if ($scope.propertyForm) {
+                $scope.propertyForm.$setDirty();
+            }
+        };
+
+        init();
+    }
+]);

--- a/src/Umbraco.Community.Contentment/DataEditors/Buttons/buttons.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/Buttons/buttons.js
@@ -14,8 +14,7 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
             defaultValue: [],
             items: [],
             enableMultiple: 0,
-            hideIcon: 0,
-            hideName: 0,
+            labelStyle: "both",
             size: "m",
         };
         var config = Object.assign({}, defaultConfig, $scope.model.config);
@@ -37,8 +36,8 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
 
             vm.items = config.items.slice();
 
-            vm.hideIcon = Object.toBoolean(config.hideIcon);
-            vm.hideName = Object.toBoolean(config.hideName);
+            vm.hideIcon = config.labelStyle === 'text';
+            vm.hideName = config.labelStyle === 'icon';
 
             vm.uniqueId = $scope.model.hasOwnProperty("dataTypeKey")
                 ? [$scope.model.alias, $scope.model.dataTypeKey.substring(0, 8)].join("-")

--- a/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
+++ b/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
@@ -296,6 +296,7 @@
   <ItemGroup>
     <Compile Include="Composing\ContentmentComposer.cs" />
     <Compile Include="Composing\ContentmentCompositionExtensions.cs" />
+    <Compile Include="DataEditors\Buttons\ButtonsDataListEditor.cs" />
     <Compile Include="Telemetry\CompositionExtensions.cs" />
     <Compile Include="Telemetry\ContentmentTelemetryComponent.cs" />
     <Compile Include="Configuration\ContentmentVersion.cs" />
@@ -418,6 +419,9 @@
     <None Include="Web\UI\App_Plugins\Contentment\package.manifest" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="DataEditors\Buttons\buttons.css" />
+    <Content Include="DataEditors\Buttons\buttons.html" />
+    <Content Include="DataEditors\Buttons\buttons.js" />
     <Content Include="DataEditors\Bytes\bytes.js" />
     <Content Include="DataEditors\CascadingDropdownList\cascading-dropdown-list.html" />
     <Content Include="DataEditors\CascadingDropdownList\cascading-dropdown-list.js" />


### PR DESCRIPTION
### Description

Adds a Buttons editor for Data List.

Using a configured data source, with the UI provides a list of selectable buttons.

![Screenshot 2021-03-19 162318](https://user-images.githubusercontent.com/209066/111812071-a1daa200-88cf-11eb-9759-53a2d79129de.png)

The configuration enables different button/icon sizes (small, medium, large), whether to hide the icon or name, _(or both! urgh, might need some UX love for that option?)_ and whether the selection is for a single or multiple values.

![Screenshot 2021-03-19 162355](https://user-images.githubusercontent.com/209066/111812267-dbaba880-88cf-11eb-8e73-db6261df54d5.png)

### Related Issues?

I've previously developed this (prior to v1.0.0) and removed it (in commit 25e54c660af5061f91847e7dc6a35de243bb3586), as I felt too many list-editor options were overwhelming for initial launch.

There has since been several requests for this, (on forum, twitter, slack and conversations), so felt it was a good time to bring it back.

### Types of changes

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
