### PR TITLE
Data List - Dropdown List - hides extra empty option. Fixes #81

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/DropdownList/DropdownListDataListEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DropdownList/DropdownListDataListEditor.cs
@@ -25,7 +25,7 @@ namespace Umbraco.Community.Contentment.DataEditors
             {
                 Key = AllowEmpty,
                 Name = "Allow empty?",
-                Description = "Enable to allow an empty option at the top of the dropdown list.",
+                Description = "Enable to allow an empty option at the top of the dropdown list.<br>When disabled, the default value will be set to the first option.",
                 View = "views/propertyeditors/boolean/boolean.html",
                 Config = new Dictionary<string, object>
                 {
@@ -35,7 +35,10 @@ namespace Umbraco.Community.Contentment.DataEditors
             new HtmlAttributesConfigurationField(),
         };
 
-        public Dictionary<string, object> DefaultValues => default;
+        public Dictionary<string, object> DefaultValues => new Dictionary<string, object>
+        {
+            { AllowEmpty, Constants.Values.True }
+        };
 
         public Dictionary<string, object> DefaultConfig => default;
 

--- a/src/Umbraco.Community.Contentment/DataEditors/DropdownList/dropdown-list.html
+++ b/src/Umbraco.Community.Contentment/DataEditors/DropdownList/dropdown-list.html
@@ -10,6 +10,6 @@
             ng-model="model.value"
             ng-change="vm.change()"
             ng-options="item.value as item.name disable when item.disabled for item in vm.items">
-        <option ng-if="vm.allowEmpty" value=""></option>
+        <option ng-if="vm.showEmpty" value=""></option>
     </select>
 </div>

--- a/src/Umbraco.Community.Contentment/DataEditors/DropdownList/dropdown-list.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/DropdownList/dropdown-list.js
@@ -20,21 +20,22 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
         var vm = this;
 
         function init() {
+
+            config.showEmpty = Object.toBoolean(config.allowEmpty);
+
+            vm.items = config.items.slice();
+
             $scope.model.value = $scope.model.value || config.defaultValue;
 
             if (Array.isArray($scope.model.value)) {
                 $scope.model.value = $scope.model.value[0];
             }
-
-            vm.items = config.items.slice();
-
-            vm.allowEmpty = Object.toBoolean(config.allowEmpty) && vm.items.some(x => x.value === $scope.model.value);
-            
-            if(vm.allowEmpty === false && $scope.model.value === '' && vm.items.length > 0) {
-                // set to first item in list when no empty values are allowed.
+            else if (config.showEmpty === false && $scope.model.value === '' && vm.items.length > 0) {
                 $scope.model.value = vm.items[0].value;
             }
-            
+
+            vm.showEmpty = config.showEmpty === true && vm.items.some(x => x.value === $scope.model.value);
+
             vm.htmlAttributes = config.htmlAttributes;
 
             vm.uniqueId = $scope.model.hasOwnProperty("dataTypeKey")
@@ -45,7 +46,7 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
         };
 
         function change() {
-            vm.allowEmpty = Object.toBoolean(config.allowEmpty) && vm.items.some(x => x.value === $scope.model.value);
+            vm.showEmpty = config.showEmpty === true && vm.items.some(x => x.value === $scope.model.value);
         };
 
         init();

--- a/src/Umbraco.Community.Contentment/DataEditors/DropdownList/dropdown-list.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/DropdownList/dropdown-list.js
@@ -29,7 +29,12 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
             vm.items = config.items.slice();
 
             vm.allowEmpty = Object.toBoolean(config.allowEmpty) && vm.items.some(x => x.value === $scope.model.value);
-
+            
+            if(vm.allowEmpty === false && $scope.model.value === '' && vm.items.length > 0) {
+                // set to first item in list when no empty values are allowed.
+                $scope.model.value = vm.items[0].value;
+            }
+            
             vm.htmlAttributes = config.htmlAttributes;
 
             vm.uniqueId = $scope.model.hasOwnProperty("dataTypeKey")


### PR DESCRIPTION
### Description
This sets the selected value to the first item in the list when creating new content and no empty items are allowed.

### Related Issues?

Fixes #81

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
     Please do not upgrade any NuGet dependencies.
     Please do not modify any licensing information, e.g. do not update the copyright year. -->

- [ ] Documentation change
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
