### PR TITLE
Update ContentmentComposer.cs so Umbraco's [ComposerAfterAttribute] etc can be used

### DIFF
--- a/src/Umbraco.Community.Contentment/Composing/ContentmentComposer.cs
+++ b/src/Umbraco.Community.Contentment/Composing/ContentmentComposer.cs
@@ -13,7 +13,7 @@ namespace Umbraco.Community.Contentment.Composing
 {
     [ComposeAfter(typeof(WebInitialComposer))]
     [RuntimeLevel(MinLevel = RuntimeLevel.Boot)]
-    internal sealed class ContentmentComposer : IUserComposer
+    public sealed class ContentmentComposer : IUserComposer
     {
         public void Compose(Composition composition)
         {


### PR DESCRIPTION
### Description

Because the visibility of the `ContentmentComposer` class wasn't public, it prevents use of Umbraco's `ComposeAfterAttribute`, `ComposeBeforeAttribute` etc, making it difficult to control ordering of other composers to run after `ContentmentComposer`

### Types of changes

- [ ] Documentation change
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
