### PR TITLE
Corrected example for disabling telemetry

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -40,11 +40,11 @@ using Umbraco.Core.Composing;
 
 namespace Our.Umbraco.Web
 {
-    public class DisableContentmentTreeComposer : IUserComposer
+    public class DisableContentmentTelemetryComposer : IUserComposer
     {
         public void Compose(Composition composition)
         {
-            composition.DisableContentmentTree();
+            composition.DisableContentmentTelemetry();
         }
     }
 }


### PR DESCRIPTION
I was peeking around the code, and found the telemetry.md page when searching for *DisableContentment**Tree***, so figured I might as well fix that 😉 