### PR TITLE
Don't run upgrades if Umbraco isn't set up #135

### DIFF
--- a/src/Umbraco.Community.Contentment/Composing/ContentmentComponent.cs
+++ b/src/Umbraco.Community.Contentment/Composing/ContentmentComponent.cs
@@ -17,21 +17,27 @@ namespace Umbraco.Community.Contentment.Composing
         private readonly IMigrationPlanExecutor _migrationPlanExecutor;
         private readonly IScopeProvider _scopeProvider;
         private readonly IKeyValueService _keyValueService;
+        private readonly IRuntimeState _runtimeState;
 
         public ContentmentComponent(
             IMigrationPlanExecutor migrationPlanExecutor,
             IScopeProvider scopeProvider,
-            IKeyValueService keyValueService)
+            IKeyValueService keyValueService,
+            IRuntimeState runtimeState)
         {
             _migrationPlanExecutor = migrationPlanExecutor;
             _scopeProvider = scopeProvider;
             _keyValueService = keyValueService;
+            _runtimeState = runtimeState;
         }
 
         public void Initialize()
         {
-            var upgrader = new Upgrader(new ContentmentPlan());
-            upgrader.Execute(_migrationPlanExecutor, _scopeProvider, _keyValueService);
+            if (_runtimeState.Level == Cms.Core.RuntimeLevel.Upgrade || _runtimeState.Level == Cms.Core.RuntimeLevel.Run)
+            {
+                var upgrader = new Upgrader(new ContentmentPlan());
+                upgrader.Execute(_migrationPlanExecutor, _scopeProvider, _keyValueService);
+            }
         }
 
         public void Terminate()


### PR DESCRIPTION
### Description
Check the RuntimeLevel before attempting to run migrations. Otherwise, Umbraco will crash during initial install.

### Related Issues?
Fixes #135 

### Types of changes
- [ ] Documentation change
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [ ] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
