### PR TITLE
Data List - Enum data source: Set log to debug instead of error

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/EnumDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/EnumDataListSource.cs
@@ -135,7 +135,7 @@ namespace Umbraco.Community.Contentment.DataEditors
             if (string.IsNullOrWhiteSpace(value) == false && type?.IsEnum == true)
             {
                 // NOTE: Can't use `Enum.TryParse` here, as it's only available with generic types in .NET 4.8.
-                try { return Enum.Parse(type, value, true); } catch (Exception ex) { _logger.Error<EnumDataListSource>(ex); }
+                try { return Enum.Parse(type, value, true); } catch (Exception ex) { _logger.Debug<EnumDataListSource>(ex); }
 
                 // If the value doesn't match the Enum field, then it is most likely set with `DataListItemAttribute.Value`.
                 var fields = type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);


### PR DESCRIPTION


### Description

Sets log level to debug instead of error so it does not flood logs on production

### Related Issues?

Fixes #169 

### Types of changes

- [ ] Documentation change
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
