### PR TITLE
[v3.0] Fix missing IOHelper usage for view resolution in v9

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/Notes/NotesDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/Notes/NotesDataEditor.cs
@@ -82,7 +82,7 @@ namespace Umbraco.Community.Contentment.DataEditors
 #endif
             {
                 ValueType = ValueTypes.Integer,
-                View = DataEditorViewPath,
+                View = _ioHelper.ResolveRelativeOrVirtualUrl(DataEditorViewPath)
             };
         }
 
@@ -107,7 +107,7 @@ namespace Umbraco.Community.Contentment.DataEditors
                 Configuration = configuration,
                 HideLabel = hideLabel,
                 ValueType = ValueTypes.Integer,
-                View = DataEditorViewPath,
+                View = _ioHelper.ResolveRelativeOrVirtualUrl(DataEditorViewPath)
             };
         }
     }

--- a/src/Umbraco.Community.Contentment/DataEditors/RenderMacro/RenderMacroDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/RenderMacro/RenderMacroDataEditor.cs
@@ -84,7 +84,7 @@ namespace Umbraco.Community.Contentment.DataEditors
 #endif
             {
                 ValueType = ValueTypes.Integer,
-                View = DataEditorViewPath,
+                View = _ioHelper.ResolveRelativeOrVirtualUrl(DataEditorViewPath)
             };
         }
 
@@ -109,7 +109,7 @@ namespace Umbraco.Community.Contentment.DataEditors
                 Configuration = configuration,
                 HideLabel = hideLabel,
                 ValueType = ValueTypes.Integer,
-                View = DataEditorViewPath,
+                View = _ioHelper.ResolveRelativeOrVirtualUrl(DataEditorViewPath)
             };
         }
     }

--- a/src/Umbraco.Community.Contentment/DataEditors/TemplatedLabel/TemplatedLabelDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/TemplatedLabel/TemplatedLabelDataEditor.cs
@@ -81,7 +81,7 @@ namespace Umbraco.Community.Contentment.DataEditors
                 _jsonSerializer)
 #endif
             {
-                View = DataEditorViewPath,
+                View = _ioHelper.ResolveRelativeOrVirtualUrl(DataEditorViewPath)
             };
         }
 
@@ -105,7 +105,7 @@ namespace Umbraco.Community.Contentment.DataEditors
             {
                 Configuration = configuration,
                 HideLabel = hideLabel,
-                View = DataEditorViewPath,
+                View = _ioHelper.ResolveRelativeOrVirtualUrl(DataEditorViewPath)
             };
         }
     }


### PR DESCRIPTION
Fix issues with ~ in view paths when using a couple of editors in v9