### PR TITLE
ValueOrDefault extension method for IPublishedElement

### DIFF
--- a/src/Umbraco.Community.Contentment/Web/Extensions/PublishedElementExtensions.cs
+++ b/src/Umbraco.Community.Contentment/Web/Extensions/PublishedElementExtensions.cs
@@ -22,6 +22,19 @@ namespace Umbraco.Extensions
 {
     public static class PublishedElementExtensions
     {
+        public static TValue ValueOrDefault<TModel, TValue>(this TModel model, string alias, string culture = null, string segment = null, TValue defaultValue = default)
+            where TModel : IPublishedElement
+        {
+            return model.Value(alias, culture, segment, Fallback.ToDefaultValue, defaultValue);
+        }
+
+        public static TValue ValueOrDefaultFor<TModel, TValue>(this TModel model, Expression<Func<TModel, TValue>> property, string culture = null, string segment = null, TValue defaultValue = default)
+            where TModel : IPublishedElement
+        {
+            var alias = GetAlias(model, property);
+            return model.Value(alias, culture, segment, Fallback.ToDefaultValue, defaultValue);
+        }
+
         public static bool HasValueFor<TModel, TValue>(this TModel model, Expression<Func<TModel, TValue>> property, string culture = null, string segment = null)
             where TModel : IPublishedElement
         {


### PR DESCRIPTION
### Description

I use `Value()`'s `defaultValue` parameter regularly, with the `Fallback.ToDefaultValue` param, the calls are verbose.
These extension methods are named in a similar vein to C# nullable type's `.GetValueOrDefault()`.

```cshtml
@Model.ValueOrDefault("pageTitle", defaultValue: Model.Name)
```

as opposed to

```cshtml
@Model.Value("pageTitle", fallback: Fallback.ToDefaultValue, defaultValue: Model.Name)
```

Basically hiding/defaulting the `fallback` param.

### Types of changes

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
