### PR TITLE
Notes - Hide property group container

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/Notes/NotesConfigurationEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/Notes/NotesConfigurationEditor.cs
@@ -35,6 +35,7 @@ namespace Umbraco.Community.Contentment.DataEditors
             });
 
             Fields.Add(new HideLabelConfigurationField());
+            Fields.Add(new HidePropertyGroupConfigurationField());
         }
     }
 }

--- a/src/Umbraco.Community.Contentment/DataEditors/Notes/notes.html
+++ b/src/Umbraco.Community.Contentment/DataEditors/Notes/notes.html
@@ -3,4 +3,4 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
 
-<div class="umb-readonlyvalue" lk-bind-html-template="model.config.notes" ng-controller="Umbraco.Community.Contentment.DataEditors.Notes.Controller as vm"></div>
+<div class="umb-readonlyvalue" lk-bind-html-template="model.config.notes" lk-hide-property-group="{{vm.hidePropertyGroup}}" ng-controller="Umbraco.Community.Contentment.DataEditors.Notes.Controller as vm"></div>

--- a/src/Umbraco.Community.Contentment/DataEditors/Notes/notes.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/Notes/notes.js
@@ -12,6 +12,7 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
 
         var defaultConfig = {
             enableDevMode: 0,
+            hidePropertyGroup: 0
         };
         var config = Object.assign({}, defaultConfig, $scope.model.config);
 
@@ -28,6 +29,8 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
                     }
                 }]);
             }
+
+            vm.hidePropertyGroup = Object.toBoolean(config.hidePropertyGroup);
 
         };
 

--- a/src/Umbraco.Community.Contentment/DataEditors/RenderMacro/RenderMacroConfigurationEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/RenderMacro/RenderMacroConfigurationEditor.cs
@@ -35,6 +35,7 @@ namespace Umbraco.Community.Contentment.DataEditors
             });
 
             Fields.Add(new HideLabelConfigurationField());
+            Fields.Add(new HidePropertyGroupConfigurationField());
         }
     }
 }

--- a/src/Umbraco.Community.Contentment/DataEditors/RenderMacro/render-macro.html
+++ b/src/Umbraco.Community.Contentment/DataEditors/RenderMacro/render-macro.html
@@ -3,7 +3,7 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
 
-<div class="umb-readonlyvalue" ng-controller="Umbraco.Community.Contentment.DataEditors.RenderMacro.Controller as vm">
+<div class="umb-readonlyvalue" lk-hide-property-group="{{vm.hidePropertyGroup}}" ng-controller="Umbraco.Community.Contentment.DataEditors.RenderMacro.Controller as vm">
     <div class="umb-rte row-fluid span8" ng-if="vm.loading === true">
         <umb-load-indicator></umb-load-indicator>
     </div>

--- a/src/Umbraco.Community.Contentment/DataEditors/RenderMacro/render-macro.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/RenderMacro/render-macro.js
@@ -14,6 +14,11 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
             return;
         }
 
+        var defaultConfig = {
+            hidePropertyGroup: 0
+        };
+        var config = Object.assign({}, defaultConfig, $scope.model.config);
+
         // console.log("render-macro.model", $scope.model);
 
         var vm = this;
@@ -58,6 +63,9 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
                 vm.loading = false;
 
             }
+
+            vm.hidePropertyGroup = Object.toBoolean(config.hidePropertyGroup);
+
         };
 
         init();

--- a/src/Umbraco.Community.Contentment/DataEditors/TemplatedLabel/TemplatedLabelConfigurationEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/TemplatedLabel/TemplatedLabelConfigurationEditor.cs
@@ -79,6 +79,7 @@ namespace Umbraco.Community.Contentment.DataEditors
             });
 
             Fields.Add(new HideLabelConfigurationField());
+            Fields.Add(new HidePropertyGroupConfigurationField());
             Fields.Add(new EnableDevModeConfigurationField());
         }
     }

--- a/src/Umbraco.Community.Contentment/DataEditors/_/ConfigurationFields/HidePropertyGroupConfigurationField.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/_/ConfigurationFields/HidePropertyGroupConfigurationField.cs
@@ -1,0 +1,27 @@
+﻿/* Copyright © 2019 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#if NET472
+using Umbraco.Core.PropertyEditors;
+#else
+using Umbraco.Cms.Core.PropertyEditors;
+#endif
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    internal sealed class HidePropertyGroupConfigurationField : ConfigurationField
+    {
+        internal const string HidePropertyGroupAlias = "hidePropertyGroup";
+
+        public HidePropertyGroupConfigurationField()
+            : base()
+        {
+            Key = HidePropertyGroupAlias;
+            Name = "Hide property group container?";
+            Description = "Select to hide the editor's containing property group box. Making it appear above/outside the property group.";
+            View = "boolean";
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/_/_directives.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/_/_directives.js
@@ -47,3 +47,34 @@ angular.module("umbraco.directives.html").directive("lkBindHtmlTemplate", [
         };
     }
 ]);
+
+angular.module("umbraco.directives.html").directive("lkHidePropertyGroup", [
+    function () {
+        return {
+            restrict: "A",
+            link: function (scope, element, attrs) {
+                if (attrs.lkHidePropertyGroup === "true") {
+
+                    /* Copyright © 2020 Perplex Digital
+                     * Parts of this Source Code has been derived from Perplex.ContentBlocks.
+                     * https://github.com/PerplexDigital/Perplex.ContentBlocks/blob/v2.1.0/src/Perplex.ContentBlocks/App_Plugins/Perplex.ContentBlocks/perplex.content-blocks.controller.js#L1137-L1156
+                     * Modified under the permissions of the MIT License.
+                     * Modifications are licensed under the Mozilla Public License. */
+                    var propertyContainer = element.closest(".umb-property-editor");
+                    var isNestedProperty = propertyContainer.parent().closest(".umb-property-editor").length > 0;
+                    if (isNestedProperty) {
+                        // NOTE: Do not hide the containing property group if we are nested in some other property editor like NestedContent.
+                        return;
+                    }
+
+                    // Starting from Umbraco 8.17 (and 9.0) it is possible to put properties in tabs again and not in a group at all. So we check for either.
+                    var container = element.closest(".umb-group-panel,.umb-box");
+                    if (container) {
+                        container.addClass("umb-group-panel--hide");
+                    }
+
+                }
+            }
+        };
+    }
+]);

--- a/src/Umbraco.Community.Contentment/Web/UI/backoffice-ui-shim.css
+++ b/src/Umbraco.Community.Contentment/Web/UI/backoffice-ui-shim.css
@@ -22,3 +22,27 @@
 .alert-form a {
     color: #1b264f;
 }
+
+/* Copyright © 2020 Perplex Digital
+ * Parts of this Source Code has been derived from Perplex.ContentBlocks.
+ * https://github.com/PerplexDigital/Perplex.ContentBlocks/blob/v2.1.0/src/Perplex.ContentBlocks/App_Plugins/Perplex.ContentBlocks/perplex.content-blocks.less#L120-L136
+ * Modified under the permissions of the MIT License.
+ * Modifications are licensed under the Mozilla Public License. */
+/* Hides the container property group (tab), see `lk-hide-property-group` directive */
+.umb-group-panel--hide {
+    all: unset;
+    background: none;
+    box-shadow: none !important;
+}
+
+    .umb-group-panel--hide .umb-group-panel__header {
+        display: none;
+    }
+
+    .umb-group-panel--hide .umb-group-panel__content {
+        padding: 0;
+    }
+
+    .umb-group-panel--hide .umb-box-content {
+        padding: 0;
+    }


### PR DESCRIPTION
### Description

Inspiration taken from [Perplex's Content Blocks](https://our.umbraco.com/packages/backoffice-extensions/perplexcontentblocks/) configuration option to hide the property's group, so that a note can visually appear above/outside the container.

It has been added as a configuration option - named **"Hide property group container?"** - on the Notes, Render Macro and Templated Label property-editors.

### Types of changes

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [x] My change requires a change to the documentation.
- [x] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
