### PR TITLE
Content Blocks - Adds "Cards" display mode

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/DisplayModes/CardsDisplayMode.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/DisplayModes/CardsDisplayMode.cs
@@ -1,0 +1,55 @@
+﻿/* Copyright © 2021 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System.Collections.Generic;
+#if NET472
+using Umbraco.Core.IO;
+using Umbraco.Core.PropertyEditors;
+#else
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.PropertyEditors;
+#endif
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    internal class CardsDisplayMode : IContentBlocksDisplayMode
+    {
+        private readonly IIOHelper _ioHelper;
+
+        public CardsDisplayMode(IIOHelper ioHelper)
+        {
+            _ioHelper = ioHelper;
+        }
+
+        public string Name => "Cards";
+
+        public string Description => "Blocks will be displayed as cards.";
+
+        public string Icon => "icon-playing-cards";
+
+        public string Group => default;
+
+        public string View => Constants.Internals.EditorsPathRoot + "content-cards.html";
+
+        public Dictionary<string, object> DefaultValues => default;
+
+        public Dictionary<string, object> DefaultConfig => new Dictionary<string, object>
+        {
+            { "enablePreview", Constants.Values.False },
+            { "allowCopy", Constants.Values.False },
+            { "allowCreateContentTemplate", Constants.Values.False },
+        };
+
+        public IEnumerable<ConfigurationField> Fields => new ConfigurationField[]
+        {
+            new NotesConfigurationField(_ioHelper, $@"<details class=""well well-small"" open>
+<summary><strong>A note about block type previews.</strong></summary>
+<p>Currently, the preview feature for block types has not been implemented for the {Name} display mode and has been temporarily disabled.</p>
+</details>", true),
+        };
+
+        public OverlaySize OverlaySize => OverlaySize.Small;
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/content-cards.html
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/content-cards.html
@@ -1,0 +1,22 @@
+﻿<!-- Copyright © 2021 Lee Kelleher.
+   - This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+<div ng-controller="Umbraco.Community.Contentment.DataEditors.ContentBlocks.Controller as vm">
+    <contentment-cards-editor ng-model="model.value"
+                              add-button-label-key="'grid_addElement'"
+                              allow-add="vm.allowAdd"
+                              allow-edit="vm.allowEdit"
+                              allow-remove="vm.allowRemove"
+                              allow-sort="vm.allowSort"
+                              get-item-name="vm.populateName"
+                              on-add="vm.add"
+                              on-edit="vm.edit"
+                              on-remove="vm.remove"
+                              on-sort="vm.sort"
+                              block-actions="vm.blockActions"
+                              property-actions="vm.propertyActions"
+                              previews="vm.previews">
+    </contentment-cards-editor>
+</div>

--- a/src/Umbraco.Community.Contentment/DataEditors/_/_components.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/_/_components.js
@@ -454,3 +454,149 @@ angular.module("umbraco.directives").component("contentmentBlocksEditor", {
 
         }]
 });
+
+angular.module("umbraco.directives").component("contentmentCardsEditor", {
+    templateUrl: "/App_Plugins/Contentment/components/cards-editor.html",
+    bindings: {
+        addButtonLabel: "@?",
+        addButtonLabelKey: "<?",
+        allowAdd: "<?",
+        allowEdit: "<?",
+        allowRemove: "<?",
+        allowSort: "<?",
+        blockActions: "<?",
+        defaultIcon: "<?",
+        getItemIcon: "<?",
+        getItemName: "<?",
+        ngModel: "=?",
+        onAdd: "<?",
+        onEdit: "<?",
+        onRemove: "<?",
+        onSort: "<?",
+        propertyActions: "<?",
+        previews: "<?",
+    },
+    require: {
+        propertyForm: "^form",
+        umbProperty: "^"
+    },
+    controllerAs: "vm",
+    controller: [
+        "$scope",
+        "localizationService",
+        function ($scope, localizationService) {
+
+            // console.log("contentmentCardsEditor", $scope.vm);
+
+            var vm = this;
+
+            vm.$onInit = function () {
+
+                vm.propertyAlias = vm.umbProperty.property.alias;
+
+                vm.sortableOptions = {
+                    axis: false,
+                    containment: "parent",
+                    cursor: "move",
+                    disabled: vm.allowSort === false,
+                    opacity: 0.7,
+                    scroll: true,
+                    tolerance: "pointer",
+                    stop: function (e, ui) {
+
+                        if (vm.onSort) {
+                            vm.onSort();
+                        }
+
+                        if (vm.propertyForm) {
+                            vm.propertyForm.$setDirty();
+                        }
+                    }
+                };
+
+                vm.add = add;
+                vm.canEdit = canEdit;
+                vm.canRemove = canRemove;
+                vm.edit = edit;
+                vm.populate = populate;
+                vm.remove = remove;
+
+                if (vm.addButtonLabelKey) {
+                    localizationService.localize(vm.addButtonLabelKey).then(function (label) {
+                        vm.addButtonLabel = label;
+                    });
+                }
+
+                if (vm.propertyActions && vm.propertyActions.length > 0) {
+                    vm.umbProperty.setPropertyActions(vm.propertyActions);
+                }
+            };
+
+            function add() {
+                if (typeof (vm.onAdd) === "function") {
+                    vm.onAdd();
+                }
+            };
+
+            function canEdit(item, $index) {
+                switch (typeof (vm.allowEdit)) {
+                    case "boolean":
+                        return vm.allowEdit;
+                    case "function":
+                        return vm.allowEdit(item, $index);
+                    default:
+                        return true;
+                }
+            };
+
+            function canRemove(item, $index) {
+                switch (typeof (vm.allowRemove)) {
+                    case "boolean":
+                        return vm.allowRemove;
+                    case "function":
+                        return vm.allowRemove(item, $index);
+                    default:
+                        return true;
+                }
+            };
+
+            function edit($index) {
+                if (typeof (vm.onEdit) === "function") {
+                    vm.onEdit($index);
+                }
+            };
+
+            function populate(item, $index, propertyName) {
+                if (typeof (vm.getItem) === "function") {
+                    return vm.getItem(item, $index, propertyName);
+                }
+
+                switch (propertyName) {
+                    case "icon":
+                        return typeof (vm.getItemIcon) === "function"
+                            ? vm.getItemIcon(item, $index)
+                            : item.icon || vm.defaultIcon;
+
+                    case "name":
+                        return typeof (vm.getItemName) === "function"
+                            ? vm.getItemName(item, $index)
+                            : item.name;
+
+                    case "description":
+                        return typeof (vm.getItemDescription) === "function"
+                            ? vm.getItemDescription(item, $index)
+                            : item.description;
+
+                    default:
+                        return item[propertyName];
+                }
+            };
+
+            function remove($index) {
+                if (typeof (vm.onRemove) === "function") {
+                    vm.onRemove($index);
+                }
+            };
+
+        }]
+});

--- a/src/Umbraco.Community.Contentment/Web/UI/App_Plugins/Contentment/components/cards-editor.html
+++ b/src/Umbraco.Community.Contentment/Web/UI/App_Plugins/Contentment/components/cards-editor.html
@@ -1,0 +1,45 @@
+﻿<!-- Copyright © 2013-present Umbraco.
+   - Parts of this Source Code has been derived from Umbraco CMS.
+   - https://github.com/umbraco/Umbraco-CMS/blob/release-8.17.0/src/Umbraco.Web.UI.Client/src/views/components/umb-grid-selector.html
+   - Modified under the permissions of the MIT License.
+   - Modifications are licensed under the Mozilla Public License.
+   - Copyright © 2021 Lee Kelleher.
+   - This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+<div class="contentment umb-grid-selector">
+    <div class="umb-grid-selector__items" ui-sortable="vm.sortableOptions" ng-model="vm.ngModel">
+        <div class="umb-grid-selector__item -sortable" ng-repeat="item in vm.ngModel">
+            <button type="button"
+                    class="btn-reset umb-grid-selector__item-content"
+                    aria-label="Edit content"
+                    ng-click="vm.edit($index)">
+                <umb-icon icon="{{_icon = vm.populate(item, $index, 'icon')}}" class="umb-grid-selector__item-icon" ng-class="_icon"></umb-icon>
+                <div class="umb-grid-selector__item-label" ng-bind="vm.populate(item, $index, 'name')"></div>
+            </button>
+            <button type="button"
+                    class="btn-reset umb-outline"
+                    aria-label="Remove content block"
+                    ng-if="vm.canRemove(item, $index)"
+                    ng-click="vm.remove($index)">
+                <umb-icon icon="icon-trash" class="umb-grid-selector__item-remove"></umb-icon>
+                <span class="sr-only">Remove content block</span>
+            </button>
+        </div>
+        <button type="button"
+                class="umb-grid-selector__item -placeholder"
+                id="{{vm.propertyAlias}}"
+                aria-label="Add content"
+                ng-if="vm.allowAdd"
+                ng-click="vm.onAdd()">
+            <div class="umb-grid-selector__item-content">
+                <umb-icon icon="icon-add" class="umb-grid-selector__item-icon"></umb-icon>
+                <div class="umb-grid-selector__item-default-label -blue">
+                    <span ng-bind="vm.addButtonLabel"></span>
+                    <span class="sr-only">...</span>
+                </div>
+            </div>
+        </button>
+    </div>
+</div>


### PR DESCRIPTION
### Description

Adds "Cards" display mode for the Content Blocks editor.

This is reuses mark-up and styles from Umbraco's native Template Picker on the Document Type editor.

This could be useful for blocks that follow a horizontal layout, as opposed to a stacked/vertical layout.

![Screenshot 2022-01-26 175757](https://user-images.githubusercontent.com/209066/151219743-7cbe8dff-bacb-45fe-bef2-9d7100622ee3.png)

### Types of changes

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
