### PR TITLE
[WIP] "Custom Value Converter" editor wrapper

### DIFF
--- a/src/Umbraco.Cms.9.0.0/Views/testMiscPage.cshtml
+++ b/src/Umbraco.Cms.9.0.0/Views/testMiscPage.cshtml
@@ -6,6 +6,10 @@
 @section body
 {
     <h1>@Model.Name</h1>
+
+    <h3>Quick test...</h3>
+    <p><code>@Model.CustomValueConverter</code></p>
+
     <h3>@nameof(Model.Properties)</h3>
     @foreach (var property in Model.Properties)
     {

--- a/src/Umbraco.Cms.9.0.0/uSync/v9/Content/test-misc.config
+++ b/src/Umbraco.Cms.9.0.0/uSync/v9/Content/test-misc.config
@@ -13,6 +13,9 @@
     <Template Key="32cf5caf-9267-4cf4-8327-2dcbd24a1cd7">testMiscPage</Template>
   </Info>
   <Properties>
+    <customValueConverter>
+      <Value><![CDATA[1130]]></Value>
+    </customValueConverter>
     <testTextbox>
       <Value><![CDATA[Hello world]]></Value>
     </testTextbox>

--- a/src/Umbraco.Cms.9.0.0/uSync/v9/ContentTypes/testmiscpage.config
+++ b/src/Umbraco.Cms.9.0.0/uSync/v9/ContentTypes/testmiscpage.config
@@ -19,6 +19,22 @@
   <Structure />
   <GenericProperties>
     <GenericProperty>
+      <Key>dfa7fb4c-3443-4f5e-a7ff-29d9ab665da6</Key>
+      <Name>Custom Value Converter</Name>
+      <Alias>customValueConverter</Alias>
+      <Definition>48bfc7e6-fe35-4cf0-ae93-e5522bc71a51</Definition>
+      <Type>Umbraco.Community.Contentment.CustomValueConverter</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>10</SortOrder>
+      <Tab Alias="misc">Misc</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
       <Key>5049c7f6-0ccb-4315-b4fb-3c860d7c39cc</Key>
       <Name>Test Textbox</Name>
       <Alias>testTextbox</Alias>
@@ -52,6 +68,12 @@
     </GenericProperty>
   </GenericProperties>
   <Tabs>
+    <Tab>
+      <Caption>Misc</Caption>
+      <Alias>misc</Alias>
+      <Type>Group</Type>
+      <SortOrder>-1</SortOrder>
+    </Tab>
     <Tab>
       <Caption>Textboxes</Caption>
       <Alias>textboxes</Alias>

--- a/src/Umbraco.Cms.9.0.0/uSync/v9/DataTypes/ContentmentCustomValueConverterExample.config
+++ b/src/Umbraco.Cms.9.0.0/uSync/v9/DataTypes/ContentmentCustomValueConverterExample.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="48bfc7e6-fe35-4cf0-ae93-e5522bc71a51" Alias="[Contentment] Custom Value Converter - Example" Level="2">
+  <Info>
+    <Name>[Contentment] Custom Value Converter - Example</Name>
+    <EditorAlias>Umbraco.Community.Contentment.CustomValueConverter</EditorAlias>
+    <DatabaseType>Ntext</DatabaseType>
+    <Folder>Test+Misc</Folder>
+  </Info>
+  <Config><![CDATA[{
+  "dataType": "umb://data-type/16393b04a15c434ba658d8e30f76a28f",
+  "valueConverter": [
+    "Umbraco.Cms.Core.PropertyEditors.TextStringValueConverter"
+  ]
+}]]></Config>
+</DataType>

--- a/src/Umbraco.Cms.9.0.0/umbraco/models/TestMiscPage.generated.cs
+++ b/src/Umbraco.Cms.9.0.0/umbraco/models/TestMiscPage.generated.cs
@@ -50,6 +50,14 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 		// properties
 
 		///<summary>
+		/// Custom Value Converter
+		///</summary>
+		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.0.0+5bfab13dc5a268714aad2426a2b68ab5561a6407")]
+		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
+		[ImplementPropertyType("customValueConverter")]
+		public virtual string CustomValueConverter => this.Value<string>(_publishedValueFallback, "customValueConverter");
+
+		///<summary>
 		/// Test Textbox: Used as a guide/comparison for the Textbox List editor.
 		///</summary>
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.0.0+5bfab13dc5a268714aad2426a2b68ab5561a6407")]

--- a/src/Umbraco.Community.Contentment/DataEditors/CustomValueConverter/CustomValueConverterConfigurationEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/CustomValueConverter/CustomValueConverterConfigurationEditor.cs
@@ -1,0 +1,111 @@
+﻿/* Copyright © 2019 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System.Collections.Generic;
+using System.Linq;
+#if NET472
+using Umbraco.Core;
+using Umbraco.Core.IO;
+using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.Services;
+using Umbraco.Core.Strings;
+using UmbConstants = Umbraco.Core.Constants;
+#else
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Strings;
+using Umbraco.Extensions;
+using UmbConstants = Umbraco.Cms.Core.Constants;
+#endif
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    internal sealed class CustomValueConverterConfigurationEditor : ConfigurationEditor
+    {
+        internal const string DataType = "dataType";
+
+        private readonly IDataTypeService _dataTypeService;
+        private readonly PropertyEditorCollection _propertyEditors;
+
+        public CustomValueConverterConfigurationEditor(
+            IDataTypeService dataTypeService,
+            PropertyEditorCollection propertyEditors,
+            PropertyValueConverterCollection propertyValueConverters,
+            IShortStringHelper shortStringHelper,
+            IIOHelper ioHelper)
+            : base()
+        {
+            _dataTypeService = dataTypeService;
+            _propertyEditors = propertyEditors;
+
+            Fields.Add(new ConfigurationField
+            {
+                Key = DataType,
+                Name = "Data type",
+                Description = "Select the data type to be wrapped with a value converter.",
+                View = "treepicker",
+                Config = new Dictionary<string, object>
+                {
+                    { "multiPicker", false },
+                    { "entityType", "DataType" },
+                    { "type", UmbConstants.Applications.Settings },
+                    { "treeAlias", UmbConstants.Trees.DataTypes },
+                    { "idType", "udi" },
+                }
+            });
+
+            var items = propertyValueConverters.Select(x =>
+            {
+                var type = x.GetType();
+
+                return new DataListItem
+                {
+                    Name = type.Name.SplitPascalCasing(shortStringHelper),
+                    Value = type.FullName,
+                    Description = type.FullName,
+                };
+            });
+
+            Fields.Add(new ConfigurationField
+            {
+                Key = "valueConverter",
+                Name = "Value converter",
+                Description = "Select the value converter to use.",
+                View = ioHelper.ResolveRelativeOrVirtualUrl(ItemPickerDataListEditor.DataEditorViewPath),
+                Config = new Dictionary<string, object>
+                {
+                    { "confirmRemoval", Constants.Values.True },
+                    { "defaultIcon", CustomValueConverterDataEditor.DataEditorIcon },
+                    { "enableFilter", Constants.Values.True },
+                    { "listType", "list" },
+                    { "overlaySize", "medium" },
+                    { Constants.Conventions.ConfigurationFieldAliases.Items, items },
+                    { Constants.Conventions.ConfigurationFieldAliases.OverlayView, ioHelper.ResolveRelativeOrVirtualUrl(ItemPickerDataListEditor.DataEditorOverlayViewPath) },
+                    { DisableSortingConfigurationField.DisableSorting, Constants.Values.True },
+                    { EnableDevModeConfigurationField.EnableDevMode, Constants.Values.True },
+                    { MaxItemsConfigurationField.MaxItems, 1 },
+                }
+            });
+        }
+
+        public override IDictionary<string, object> ToValueEditor(object configuration)
+        {
+            var config = base.ToValueEditor(configuration);
+
+            if (config.TryGetValueAs(DataType, out GuidUdi udi) == true)
+            {
+                var dataType = _dataTypeService.GetDataType(udi.Guid);
+                if (dataType != null && _propertyEditors.TryGet(dataType.EditorAlias, out var dataEditor) == true)
+                {
+                    return dataEditor.GetConfigurationEditor().ToValueEditor(dataType.Configuration);
+                }
+            }
+
+            return base.ToValueEditor(configuration);
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/CustomValueConverter/CustomValueConverterDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/CustomValueConverter/CustomValueConverterDataEditor.cs
@@ -1,0 +1,130 @@
+﻿/* Copyright © 2019 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System.Collections.Generic;
+#if NET472
+using Umbraco.Core;
+using Umbraco.Core.IO;
+using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.Services;
+using Umbraco.Core.Strings;
+#else
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Extensions;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Strings;
+#endif
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    public sealed class CustomValueConverterDataEditor : IDataEditor
+    {
+        internal const string DataEditorAlias = Constants.Internals.DataEditorAliasPrefix + "CustomValueConverter";
+        internal const string DataEditorName = Constants.Internals.DataEditorNamePrefix + "Custom Value Converter";
+        internal const string DataEditorViewPath = Constants.Internals.EmptyEditorViewPath;
+        internal const string DataEditorIcon = "icon-defrag";
+
+        private readonly IDataTypeService _dataTypeService;
+        private readonly PropertyEditorCollection _propertyEditors;
+        private readonly PropertyValueConverterCollection _propertyValueConverters;
+        private readonly IIOHelper _ioHelper;
+        private readonly IShortStringHelper _shortStringHelper;
+
+#if NET472
+        public CustomValueConverterDataEditor(
+            IDataTypeService dataTypeService,
+            PropertyEditorCollection propertyEditors,
+            PropertyValueConverterCollection propertyValueConverters,
+            IIOHelper ioHelper,
+            IShortStringHelper shortStringHelper)
+        {
+            _dataTypeService = dataTypeService;
+            _propertyEditors = propertyEditors;
+            _propertyValueConverters = propertyValueConverters;
+            _ioHelper = ioHelper;
+            _shortStringHelper = shortStringHelper;
+        }
+#else
+        private readonly ILocalizedTextService _localizedTextService;
+        private readonly IJsonSerializer _jsonSerializer;
+
+        public CustomValueConverterDataEditor(
+            IDataTypeService dataTypeService,
+            PropertyEditorCollection propertyEditors,
+            PropertyValueConverterCollection propertyValueConverters,
+            IIOHelper ioHelper,
+            ILocalizedTextService localizedTextService,
+            IShortStringHelper shortStringHelper,
+            IJsonSerializer jsonSerializer)
+        {
+            _dataTypeService = dataTypeService;
+            _propertyEditors = propertyEditors;
+            _propertyValueConverters = propertyValueConverters;
+            _ioHelper = ioHelper;
+            _localizedTextService = localizedTextService;
+            _shortStringHelper = shortStringHelper;
+            _jsonSerializer = jsonSerializer;
+        }
+#endif
+
+        public string Alias => DataEditorAlias;
+
+        public EditorType Type => EditorType.PropertyValue;
+
+        public string Name => DataEditorName;
+
+        public string Icon => DataEditorIcon;
+
+        public string Group => Constants.Conventions.PropertyGroups.Code;
+
+        public bool IsDeprecated => false;
+
+        public IDictionary<string, object> DefaultConfiguration => default;
+
+        public IPropertyIndexValueFactory PropertyIndexValueFactory => new DefaultPropertyIndexValueFactory();
+
+        public IConfigurationEditor GetConfigurationEditor() => new CustomValueConverterConfigurationEditor(
+            _dataTypeService,
+            _propertyEditors,
+            _propertyValueConverters,
+            _shortStringHelper,
+            _ioHelper);
+
+        public IDataValueEditor GetValueEditor()
+        {
+#if NET472
+            return new DataValueEditor
+#else
+            return new DataValueEditor(
+                _localizedTextService,
+                _shortStringHelper,
+                _jsonSerializer)
+#endif
+            {
+                ValueType = ValueTypes.Json,
+                View = _ioHelper.ResolveRelativeOrVirtualUrl(DataEditorViewPath)
+            };
+        }
+
+        public IDataValueEditor GetValueEditor(object configuration)
+        {
+            if (configuration is Dictionary<string, object> config &&
+                config.TryGetValueAs(CustomValueConverterConfigurationEditor.DataType, out GuidUdi udi) == true)
+            {
+                var dataType = _dataTypeService.GetDataType(udi.Guid);
+                if (dataType != null && _propertyEditors.TryGet(dataType.EditorAlias, out var dataEditor) == true)
+                {
+                    return dataEditor.GetValueEditor();
+                }
+            }
+
+            return GetValueEditor();
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/CustomValueConverter/CustomValueConverterValueConverter.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/CustomValueConverter/CustomValueConverterValueConverter.cs
@@ -1,0 +1,136 @@
+﻿/* Copyright © 2019 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+#if NET472
+using Umbraco.Core;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.Services;
+#else
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
+#endif
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    public sealed class CustomValueConverterValueConverter : PropertyValueConverterBase
+    {
+        private readonly IDataTypeService _dataTypeService;
+        private readonly PropertyValueConverterCollection _propertyValueConverters;
+        private readonly IPublishedContentTypeFactory _publishedContentTypeFactory;
+
+        public CustomValueConverterValueConverter(
+            IDataTypeService dataTypeService,
+            PropertyValueConverterCollection propertyValueConverters,
+            IPublishedContentTypeFactory publishedContentTypeFactory)
+        {
+            _dataTypeService = dataTypeService;
+            _propertyValueConverters = propertyValueConverters;
+            _publishedContentTypeFactory = publishedContentTypeFactory;
+        }
+
+        public override bool IsConverter(IPublishedPropertyType propertyType) => propertyType.EditorAlias.InvariantEquals(CustomValueConverterDataEditor.DataEditorAlias);
+
+        public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
+        {
+            return TryGetPropertyValueConverter(propertyType, out var converter) == true
+                ? converter.GetPropertyValueType(propertyType)
+                : typeof(object);
+        }
+
+        public override object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
+        {
+            return TryGetPropertyValueConverter(propertyType, out var converter) == true
+                ? converter.ConvertSourceToIntermediate(owner, propertyType, source, preview)
+                : base.ConvertSourceToIntermediate(owner, propertyType, source, preview);
+        }
+
+        public override object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
+        {
+            return TryGetPropertyValueConverter(propertyType, out var converter) == true
+                ? converter.ConvertIntermediateToObject(owner, propertyType, referenceCacheLevel, inter, preview)
+                : base.ConvertIntermediateToObject(owner, propertyType, referenceCacheLevel, inter, preview);
+        }
+
+        public override object ConvertIntermediateToXPath(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
+        {
+            return TryGetPropertyValueConverter(propertyType, out var converter) == true
+                ? converter.ConvertIntermediateToXPath(owner, propertyType, referenceCacheLevel, inter, preview)
+                : base.ConvertIntermediateToXPath(owner, propertyType, referenceCacheLevel, inter, preview);
+        }
+
+        private bool TryGetPropertyValueConverter(IPublishedPropertyType propertyType, out IPropertyValueConverter converter)
+        {
+            // TODO: [LK] Look at caching this, as it is called every time! ಠ_ಠ
+
+            if (propertyType.DataType.Configuration is Dictionary<string, object> configuration)
+            {
+                // NOTE: Try to get the custom value converter first, otherwise fallback on the property's own converter.
+                if (configuration.TryGetValueAs("valueConverter", out JArray array) == true &&
+                    array.Count > 0 &&
+                    array[0].Value<string>() is string valueConverter &&
+                    string.IsNullOrWhiteSpace(valueConverter) == false)
+                {
+                    converter = _propertyValueConverters.FirstOrDefault(x => valueConverter.InvariantEquals(x.GetType().FullName) == true);
+
+                    if (converter != default)
+                    {
+                        return true;
+                    }
+                }
+
+                if (configuration.TryGetValueAs(CustomValueConverterConfigurationEditor.DataType, out GuidUdi udi) == true)
+                {
+                    var dataType = _dataTypeService.GetDataType(udi.Guid);
+                    if (dataType != null)
+                    {
+                        var innerPropertyType = _publishedContentTypeFactory.CreatePropertyType(
+                            propertyType.ContentType,
+                            propertyType.Alias,
+                            dataType.Id,
+                            ContentVariation.Nothing);
+
+                        converter = _propertyValueConverters.FirstOrDefault(x => x.IsConverter(innerPropertyType) == true);
+
+                        if (converter != default)
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            converter = default;
+            return false;
+        }
+    }
+
+    // TODO: [LK] Remove this class. It is only here as an initial example.
+    public class ReverseMyStringValueConverter : PropertyValueConverterBase
+    {
+        public override bool IsConverter(IPublishedPropertyType propertyType) => false;
+
+        public override Type GetPropertyValueType(IPublishedPropertyType propertyType) => typeof(string);
+
+        public override object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
+        {
+            if (inter is string str)
+            {
+                return new string(str.Reverse().ToArray());
+            }
+
+            return Guid.NewGuid().ToString();
+        }
+    }
+}


### PR DESCRIPTION
### Description

@abjerner @greystate You may be interested in this one?

Adds a wrapper property-editor that can override the value-converter with another `IPropertyValueConverter`, (either an existing or a custom one).

### Related Issues?

This idea first came up in [the discussion of having a custom value converter for the Data List editor](https://github.com/leekelleher/umbraco-contentment/discussions/89), #89. I wasn't fully happy with that direction for Data List specifically - _I felt it introduced more complexity than I wanted to maintain._

_But!_ Since that discussion _(18 months ago)_, I have been curious if there was another way to tackle it.

So I tried.

**How does it work?**

When you create the Data Type, you would pick a Data Type (property-editor) that you want to wrap. In this example I'm using Contentment's Text Input editor, (but any editor could be used).

![Screenshot 2022-02-07 183830](https://user-images.githubusercontent.com/209066/152851134-fde8cc0b-24d7-4432-a58d-ee9dba9803a7.png)

Then you would select a value-converter to use. If left empty, then the default value-converter for that property-editor would be used as a fallback.  In this example, I've picked Umbraco's [`TextStringValueConverter`](https://github.com/umbraco/Umbraco-CMS/blob/release-9.0.0/src/Umbraco.Core/PropertyEditors/TextStringValueConverter.cs).

![Screenshot 2022-02-07 183901](https://user-images.githubusercontent.com/209066/152851135-b38bca26-393d-4f15-a7a4-b3ab3290290d.png)

Now, once you've got ModelsBuilder (or not) all wired up, you could go to a Content page and enter a value... for this example, let's say it's a numeric string value, e.g. `"1234"`.

Once published, on the frontend the value would be outputted as `1234` with value-type of `string` (`System.String`).

Now, back to the Data Type's config... if we change the value-converter to, Umbraco's [`IntegerValueConverter`](https://github.com/umbraco/Umbraco-CMS/blob/release-9.0.0/src/Umbraco.Core/PropertyEditors/ValueConverters/IntegerValueConverter.cs) ... then re-build/compile the ModelsBuilder for the Content Type, then when we refresh the page on the frontend, the value will still be `1234`, but now it will be of value-type `int` (`System.Int32`).

But... let's go a step further, and just for this specific example, the number `1234` is the node ID of a page. So if we changed the value-converter to say Umbraco's [`ContentPickerValueConverter`](https://github.com/umbraco/Umbraco-CMS/blob/release-9.0.0/src/Umbraco.Core/PropertyEditors/ValueConverters/ContentPickerValueConverter.cs) ... then did all the ModelBuilder re-build ... on the frontend, the value-type would now be the `IPublishedContent` object (using whatever related ModelsBuilder class/type).

Meaning that the value-converter can be configured separately from the property-editor.

My work-in-progress code has an example called [`ReverseMyStringValueConverter`](https://github.com/leekelleher/umbraco-contentment/pull/196/files#diff-24757a48343e0f4df23922de95eb100b7f445cf56b3a5e7fe9cf73d6e4681089R120) - which reverses the string value, useless but proves the example.

I'd welcome any feedback, whether this is a good idea or have I gone completely crazy? 😜

### Types of changes

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [x] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
