### PR TITLE
Configuration Editor: Introduces `IContentmentListTemplateItem` interface

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/ConfigurationEditor/ConfigurationEditorUtility.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/ConfigurationEditor/ConfigurationEditorUtility.cs
@@ -65,7 +65,7 @@ namespace Umbraco.Community.Contentment.DataEditors
                 ? item.Fields
                 : Enumerable.Empty<ConfigurationField>();
 
-            return new ConfigurationEditorModel
+            var model = new ConfigurationEditorModel
             {
                 Key = type.GetFullNameWithAssembly(),
                 Name = item.Name ?? type.Name.SplitPascalCasing(shortStringHelper),
@@ -76,6 +76,14 @@ namespace Umbraco.Community.Contentment.DataEditors
                 DefaultValues = item.DefaultValues,
                 OverlaySize = item.OverlaySize,
             };
+
+            if (item is IContentmentListTemplateItem lti)
+            {
+                model.NameTemplate = lti.NameTemplate;
+                model.DescriptionTemplate = lti.DescriptionTemplate;
+            }
+
+            return model;
         }
 
         public IEnumerable<ConfigurationEditorModel> GetConfigurationEditorModels<T>(IShortStringHelper shortStringHelper, bool ignoreFields = false)

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/EnumDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/EnumDataListSource.cs
@@ -27,7 +27,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class EnumDataListSource : IDataListSource, IDataListSourceValueConverter
+    public sealed class EnumDataListSource : IDataListSource, IDataListSourceValueConverter, IContentmentListTemplateItem
     {
         private readonly Dictionary<Type, (List<DataListItem>, Dictionary<string, object>)> _lookup;
         private readonly IIOHelper _ioHelper;
@@ -57,7 +57,11 @@ namespace Umbraco.Community.Contentment.DataEditors
 
         public string Name => ".NET Enumeration";
 
+        public string NameTemplate => default;
+
         public string Description => "Select an enumeration from a .NET assembly as the data source.";
+
+        public string DescriptionTemplate => "{{ enumType[1] }}";
 
         public string Icon => "icon-indent";
 

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/JsonDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/JsonDataListSource.cs
@@ -26,7 +26,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class JsonDataListSource : IDataListSource
+    public sealed class JsonDataListSource : IDataListSource, IContentmentListTemplateItem
     {
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly IIOHelper _ioHelper;
@@ -54,7 +54,11 @@ namespace Umbraco.Community.Contentment.DataEditors
 
         public string Name => "JSON Data";
 
+        public string NameTemplate => default;
+
         public string Description => "Configure JSON data to populate the data source.";
+
+        public string DescriptionTemplate => "{{ url }}";
 
         public string Icon => "icon-brackets";
 

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/TextDelimitedDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/TextDelimitedDataListSource.cs
@@ -24,7 +24,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class TextDelimitedDataListSource : IDataListSource
+    public sealed class TextDelimitedDataListSource : IDataListSource, IContentmentListTemplateItem
     {
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly IIOHelper _ioHelper;
@@ -57,7 +57,11 @@ namespace Umbraco.Community.Contentment.DataEditors
 
         public string Name => "Text Delimited Data";
 
+        public string NameTemplate => default;
+
         public string Description => "Configure text-delimited data to populate the data source.";
+
+        public string DescriptionTemplate => "{{ url }}";
 
         public string Icon => "icon-fa fa-file-text-o";
 

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/XmlDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/XmlDataListSource.cs
@@ -18,7 +18,6 @@ using Umbraco.Core.Logging;
 using Umbraco.Core.PropertyEditors;
 #else
 using Microsoft.Extensions.Logging;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.PropertyEditors;
@@ -27,7 +26,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class XmlDataListSource : IDataListSource
+    public sealed class XmlDataListSource : IDataListSource, IContentmentListTemplateItem
     {
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly IIOHelper _ioHelper;
@@ -60,7 +59,11 @@ namespace Umbraco.Community.Contentment.DataEditors
 
         public string Name => "XML Data";
 
+        public string NameTemplate => default;
+
         public string Description => "Configure XML data to populate the data source.";
+
+        public string DescriptionTemplate => "{{ url }}";
 
         public string Icon => "icon-code";
 

--- a/src/Umbraco.Community.Contentment/DataEditors/_/IContentmentListTemplateItem.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/_/IContentmentListTemplateItem.cs
@@ -1,0 +1,17 @@
+﻿/* Copyright © 2022 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System.ComponentModel;
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    public interface IContentmentListTemplateItem : IContentmentListItem
+    {
+        string NameTemplate { get; }
+
+        string DescriptionTemplate { get; }
+    }
+}


### PR DESCRIPTION
Recently, @dchallener asked me if it was possible in the Data List config to modify the data-source's label, based on its options.

It wasn't possible. 😕 

_Hold my beer._ 🍺 

### Description

Support for this was already kind-of there, in that the [`ConfigurationEditorModel`](https://github.com/leekelleher/umbraco-contentment/blob/3.2.0/src/Umbraco.Community.Contentment/DataEditors/ConfigurationEditor/ConfigurationEditorModel.cs) had properties for [`NameTemplate` and `DescriptionTemplate`](https://github.com/leekelleher/umbraco-contentment/blob/3.2.0/src/Umbraco.Community.Contentment/DataEditors/ConfigurationEditor/ConfigurationEditorModel.cs#L41), and [the AngularJS parts were already wired up](https://github.com/leekelleher/umbraco-contentment/blob/3.2.0/src/Umbraco.Community.Contentment/DataEditors/ConfigurationEditor/configuration-editor.js#L67-L69).

The missing piece was that the [`ConfigurationEditorUtility` didn't wire them up!](https://github.com/leekelleher/umbraco-contentment/blob/3.2.0/src/Umbraco.Community.Contentment/DataEditors/ConfigurationEditor/ConfigurationEditorUtility.cs#L68-L78) _(for reasons I can't recall)._ Meaning that the [`IDataListSource`](https://github.com/leekelleher/umbraco-contentment/blob/3.2.0/src/Umbraco.Community.Contentment/DataEditors/DataList/IDataListSource.cs) and [`IDataListEditor`](https://github.com/leekelleher/umbraco-contentment/blob/3.2.0/src/Umbraco.Community.Contentment/DataEditors/DataList/IDataListEditor.cs) interface implementations couldn't make use of this feature.

I didn't want to change those interfaces, nor the underlying [`IContentmentListItem` base interface](https://github.com/leekelleher/umbraco-contentment/blob/3.2.0/src/Umbraco.Community.Contentment/DataEditors/_/IContentmentListItem.cs), as that would be a big breaking-change, _(and I didn't want to do a v4.0 just yet, that is for Umbraco v10 support)_. So I've opted to introduce a new interface, `IContentmentListTemplateItem`, this will enable the `NameTemplate` and `DescriptionTemplate` properties to be set.

I have added examples for the Data List data-sources for Enum, JSON, Text Delimited and XML, to display the main configuration option in the item's description field.


### Types of changes

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [x] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
