### PR TITLE
Support Content Block editor use when not in Content / Media Tree

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/content-blocks.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/content-blocks.js
@@ -45,6 +45,11 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
             var currentNode = editorState.getCurrent();
             config.currentPageId = currentNode.id > 0 ? currentNode.id : currentNode.parentId;
 
+            // Support Content not in Content / Media Tree
+            if (!config.currentPageId) {
+                config.currentPageId = -1;
+            }
+
             $scope.model.value = $scope.model.value || [];
 
             if ($scope.model.value === "") {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

### Description

<!-- Please include a summary of the change and which issue is fixed.
     Please also include relevant motivation and context.
     List any dependencies that are required for this change. -->
Adds support for there being no currentNode in editorState. This allows for adding element types to the content blocks list when using Konstrukt. Sets the currentPageId to be -1 if there is no currentNode.Id or currentNode.ParentId.

### Related Issues?

<!-- If suggesting a new feature or change, please discuss it in an issue first.
     If fixing a bug for an existing issue, please link to the issue here: -->

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
     Please do not upgrade any NuGet dependencies.
     Please do not modify any licensing information, e.g. do not update the copyright year. -->

- [ ] Documentation change
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
