### PR TITLE
Content Blocks: Updated UI for "Cards" display mode

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/DisplayModes/CardsDisplayMode.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/DisplayModes/CardsDisplayMode.cs
@@ -33,13 +33,17 @@ namespace Umbraco.Community.Contentment.DataEditors
 
         public string View => Constants.Internals.EditorsPathRoot + "content-cards.html";
 
-        public Dictionary<string, object> DefaultValues => default;
+        public Dictionary<string, object> DefaultValues => new Dictionary<string, object>
+        {
+            { "allowCopy", Constants.Values.True },
+            { "allowCreateContentTemplate", Constants.Values.True },
+        };
 
         public Dictionary<string, object> DefaultConfig => new Dictionary<string, object>
         {
             { "enablePreview", Constants.Values.False },
-            { "allowCopy", Constants.Values.False },
-            { "allowCreateContentTemplate", Constants.Values.False },
+            { "allowCopy", Constants.Values.True },
+            { "allowCreateContentTemplate", Constants.Values.True },
         };
 
         public IEnumerable<ConfigurationField> Fields => new ConfigurationField[]
@@ -48,6 +52,20 @@ namespace Umbraco.Community.Contentment.DataEditors
 <summary><strong>A note about block type previews.</strong></summary>
 <p>Currently, the preview feature for block types has not been implemented for the {Name} display mode and has been temporarily disabled.</p>
 </details>", true),
+            new ConfigurationField
+            {
+                Key = "allowCopy",
+                Name = "Allow copy?",
+                Description = "Select to enable copying content blocks.",
+                View = "views/propertyeditors/boolean/boolean.html",
+            },
+            new ConfigurationField
+            {
+                Key = "allowCreateContentTemplate",
+                Name = "Allow create content template?",
+                Description = "Select to enable the 'Create content template' feature.",
+                View = "views/propertyeditors/boolean/boolean.html",
+            }
         };
 
         public OverlaySize OverlaySize => OverlaySize.Small;

--- a/src/Umbraco.Community.Contentment/DataEditors/_/_components.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/_/_components.js
@@ -494,9 +494,10 @@ angular.module("umbraco.directives").component("contentmentCardsEditor", {
                 vm.propertyAlias = vm.umbProperty.property.alias;
 
                 vm.sortableOptions = {
-                    axis: false,
-                    containment: "parent",
-                    cursor: "move",
+                    "ui-floating": true,
+                    items: ".umb-block-card",
+                    cursor: "grabbing",
+                    placeholder: "umb-block-card --sortable-placeholder",
                     disabled: vm.allowSort === false,
                     opacity: 0.7,
                     scroll: true,
@@ -528,6 +529,16 @@ angular.module("umbraco.directives").component("contentmentCardsEditor", {
 
                 if (vm.propertyActions && vm.propertyActions.length > 0) {
                     vm.umbProperty.setPropertyActions(vm.propertyActions);
+                }
+
+                if (vm.blockActions && vm.blockActions.length > 0) {
+                    vm.blockActions.forEach(function (x) {
+                        x.forEach(function (y) {
+                            localizationService.localize(y.labelKey).then(function (label) {
+                                y.label = label;
+                            });
+                        });
+                    });
                 }
             };
 

--- a/src/Umbraco.Community.Contentment/Web/UI/App_Plugins/Contentment/components/cards-editor.html
+++ b/src/Umbraco.Community.Contentment/Web/UI/App_Plugins/Contentment/components/cards-editor.html
@@ -1,6 +1,7 @@
 ﻿<!-- Copyright © 2013-present Umbraco.
    - Parts of this Source Code has been derived from Umbraco CMS.
-   - https://github.com/umbraco/Umbraco-CMS/blob/release-8.17.0/src/Umbraco.Web.UI.Client/src/views/components/umb-grid-selector.html
+   - https://github.com/umbraco/Umbraco-CMS/blob/release-8.17.0/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.html
+   - https://github.com/umbraco/Umbraco-CMS/blob/release-8.17.0/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
    - Modified under the permissions of the MIT License.
    - Modifications are licensed under the Mozilla Public License.
    - Copyright © 2021 Lee Kelleher.
@@ -8,38 +9,43 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
 
-<div class="contentment umb-grid-selector">
-    <div class="umb-grid-selector__items" ui-sortable="vm.sortableOptions" ng-model="vm.ngModel">
-        <div class="umb-grid-selector__item -sortable" ng-repeat="item in vm.ngModel">
-            <button type="button"
-                    class="btn-reset umb-grid-selector__item-content"
-                    aria-label="Edit content"
-                    ng-click="vm.edit($index)">
-                <umb-icon icon="{{_icon = vm.populate(item, $index, 'icon')}}" class="umb-grid-selector__item-icon" ng-class="_icon"></umb-icon>
-                <div class="umb-grid-selector__item-label" ng-bind="vm.populate(item, $index, 'name')"></div>
-            </button>
-            <button type="button"
-                    class="btn-reset umb-outline"
-                    aria-label="Remove content block"
-                    ng-if="vm.canRemove(item, $index)"
-                    ng-click="vm.remove($index)">
-                <umb-icon icon="icon-trash" class="umb-grid-selector__item-remove"></umb-icon>
-                <span class="sr-only">Remove content block</span>
-            </button>
-        </div>
-        <button type="button"
-                class="umb-grid-selector__item -placeholder"
-                id="{{vm.propertyAlias}}"
-                aria-label="Add content"
-                ng-if="vm.allowAdd"
-                ng-click="vm.onAdd()">
-            <div class="umb-grid-selector__item-content">
-                <umb-icon icon="icon-add" class="umb-grid-selector__item-icon"></umb-icon>
-                <div class="umb-grid-selector__item-default-label -blue">
-                    <span ng-bind="vm.addButtonLabel"></span>
-                    <span class="sr-only">...</span>
+<div class="contentment umb-block-list-block-configuration">
+    <div class="umb-block-card-grid" ui-sortable="vm.sortableOptions" ng-model="vm.ngModel">
+        <div class="umb-block-card" ng-repeat="item in vm.ngModel" ng-click="vm.edit($index)">
+            <div class="__showcase">
+                <div class="__icon">
+                    <umb-icon icon="{{_icon = vm.populate(item, $index, 'icon')}}" ng-class="_icon"></umb-icon>
                 </div>
             </div>
+            <div class="__info">
+                <div class="__name" ng-bind="vm.populate(item, $index, 'name')"></div>
+                <!--<div class="__subname" ng-bind="vm.populate(item, $index, 'description')"></div>-->
+            </div>
+            <div class="__actions">
+                <button type="button"
+                        class="btn-reset __action umb-outline"
+                        title="{{btn.label}}"
+                        ng-click="btn.method(); $event.stopPropagation();"
+                        ng-repeat="btn in vm.blockActions[$index]">
+                    <umb-icon icon="icon-{{btn.icon}}" class="icon"></umb-icon>
+                    <span class="sr-only" ng-bind="btn.label"></span>
+                </button>
+                <button type="button"
+                        class="btn-reset __action umb-outline"
+                        ng-if="vm.canRemove(item, $index)"
+                        ng-click="vm.remove($index); $event.stopPropagation();">
+                    <umb-icon icon="icon-trash" class="icon"></umb-icon>
+                    <localize key="general_delete" class="sr-only">Remove</localize>
+                </button>
+            </div>
+        </div>
+        <button type="button"
+                class="btn-reset __add-button"
+                id="{{vm.propertyAlias}}"
+                ng-if="vm.allowAdd"
+                ng-click="vm.onAdd()">
+            <span ng-bind="vm.addButtonLabel"></span>
+            <span class="sr-only">...</span>
         </button>
     </div>
 </div>

--- a/src/Umbraco.Community.Contentment/Web/UI/backoffice-ui-shim.css
+++ b/src/Umbraco.Community.Contentment/Web/UI/backoffice-ui-shim.css
@@ -23,6 +23,12 @@
     color: #1b264f;
 }
 
+/* Block List Configuration Card, fixes icon position of action buttons. */
+.contentment .umb-block-card .__actions > button {
+    padding-top: 3px;
+}
+
+
 /* Copyright © 2020 Perplex Digital
  * Parts of this Source Code has been derived from Perplex.ContentBlocks.
  * https://github.com/PerplexDigital/Perplex.ContentBlocks/blob/v2.1.0/src/Perplex.ContentBlocks/App_Plugins/Perplex.ContentBlocks/perplex.content-blocks.less#L120-L136


### PR DESCRIPTION
### Description

On Umbraco's Block List editor configuration for the element types, there is a newer (fresher) UI for the cards.

My initial implementation of the Cards display mode was based on Umbraco's Template Picker (on the Document Type editor), see PR #194 - but it felt dated when compared to the fresher card UI.

**Before** (old card UI)

![1](https://user-images.githubusercontent.com/209066/169857610-684e58c1-fe03-4158-b075-580535fa8f70.png)

**After** (new card UI)

![2](https://user-images.githubusercontent.com/209066/169857618-2d99cfac-6102-4fd0-96ad-844b7cf7aaa5.png)


### Types of changes

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
