### PR TITLE
Notes/RenderMacro - added Deploy Connectors

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentXPathDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentXPathDataListSource.cs
@@ -160,7 +160,7 @@ namespace Umbraco.Community.Contentment.DataEditors
 
         public object ConvertValue(Type type, string value)
         {
-            return UdiParser.TryParse(value, out var udi) == true
+            return UdiParser.TryParse(value, out Udi udi) == true
                 ? _umbracoContextAccessor.GetRequiredUmbracoContext().Content.GetById(udi)
                 : default;
         }

--- a/src/Umbraco.Community.Contentment/DataEditors/EditorNotes/EditorNotesConfigurationConnector.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/EditorNotes/EditorNotesConfigurationConnector.cs
@@ -1,0 +1,107 @@
+﻿/* Copyright © 2022 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System.Collections.Generic;
+#if NET472
+using Umbraco.Core;
+using Umbraco.Core.Deploy;
+using Umbraco.Core.Models;
+using Umbraco.Core.PropertyEditors;
+using UmbConstants = Umbraco.Core.Constants;
+#else
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Deploy;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Extensions;
+using UmbConstants = Umbraco.Cms.Core.Constants;
+#endif
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    internal sealed class EditorNotesConfigurationConnector : IDataTypeConfigurationConnector
+    {
+#if NET472 == false
+        private readonly IConfigurationEditorJsonSerializer _configurationEditorJsonSerializer;
+#endif
+        private readonly ILocalLinkParser _localLinkParser;
+        private readonly IImageSourceParser _imageSourceParser;
+        private readonly IMacroParser _macroParser;
+
+        public IEnumerable<string> PropertyEditorAliases => new[] { EditorNotesDataEditor.DataEditorName };
+
+        public EditorNotesConfigurationConnector(
+#if NET472 == false
+            IConfigurationEditorJsonSerializer configurationEditorJsonSerializer,
+#endif
+            ILocalLinkParser localLinkParser,
+            IImageSourceParser imageSourceParser,
+            IMacroParser macroParser)
+        {
+#if NET472 == false
+            _configurationEditorJsonSerializer = configurationEditorJsonSerializer;
+#endif
+            _localLinkParser = localLinkParser;
+            _imageSourceParser = imageSourceParser;
+            _macroParser = macroParser;
+        }
+
+        public object FromArtifact(IDataType dataType, string configuration)
+        {
+            var dataTypeConfigurationEditor = dataType.Editor.GetConfigurationEditor();
+#if NET472
+            var db = dataTypeConfigurationEditor.FromDatabase(configuration);
+#else
+            var db = dataTypeConfigurationEditor.FromDatabase(configuration, _configurationEditorJsonSerializer);
+#endif
+            if (db is Dictionary<string, object> config &&
+                config.TryGetValueAs(EditorNotesConfigurationEditor.Message, out string notes) == true &&
+                string.IsNullOrWhiteSpace(notes) == false)
+            {
+                notes = _localLinkParser.FromArtifact(notes);
+                notes = _imageSourceParser.FromArtifact(notes);
+                notes = _macroParser.FromArtifact(notes);
+
+                config[EditorNotesConfigurationEditor.Message] = notes;
+
+                return config;
+            }
+
+            return db;
+        }
+
+        public string ToArtifact(IDataType dataType, ICollection<ArtifactDependency> dependencies)
+        {
+            if (dataType.Configuration is Dictionary<string, object> config &&
+                config.TryGetValueAs(EditorNotesConfigurationEditor.Message, out string notes) == true &&
+                string.IsNullOrWhiteSpace(notes) == false)
+            {
+                var udis = new List<Udi>();
+
+                notes = _localLinkParser.ToArtifact(notes, udis);
+                notes = _imageSourceParser.ToArtifact(notes, udis);
+                notes = _macroParser.ToArtifact(notes, udis);
+
+                foreach (var udi in udis)
+                {
+                    var mode = udi.EntityType == UmbConstants.UdiEntityType.Macro
+                        ? ArtifactDependencyMode.Match
+                        : ArtifactDependencyMode.Exist;
+
+                    dependencies.Add(new ArtifactDependency(udi, false, mode));
+                }
+
+                config[EditorNotesConfigurationEditor.Message] = notes;
+            }
+
+#if NET472
+            return ConfigurationEditor.ToDatabase(dataType.Configuration);
+#else
+            return ConfigurationEditor.ToDatabase(dataType.Configuration, _configurationEditorJsonSerializer);
+#endif
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/EditorNotes/EditorNotesConfigurationEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/EditorNotes/EditorNotesConfigurationEditor.cs
@@ -17,6 +17,8 @@ namespace Umbraco.Community.Contentment.DataEditors
 {
     internal sealed class EditorNotesConfigurationEditor : ConfigurationEditor
     {
+        internal const string Message = "message";
+
         public EditorNotesConfigurationEditor(IIOHelper ioHelper)
             : base()
         {
@@ -62,8 +64,8 @@ namespace Umbraco.Community.Contentment.DataEditors
 
             Fields.Add(new ConfigurationField
             {
-                Key = "message",
-                Name = "Message",
+                Key = Message,
+                Name = nameof(Message),
                 Description = "Enter the notes to be displayed for the content editor.",
                 View = ioHelper.ResolveRelativeOrVirtualUrl("~/umbraco/views/propertyeditors/rte/rte.html"),
                 Config = new Dictionary<string, object>

--- a/src/Umbraco.Community.Contentment/DataEditors/Notes/NotesConfigurationConnector.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/Notes/NotesConfigurationConnector.cs
@@ -1,0 +1,108 @@
+﻿/* Copyright © 2022 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System.Collections.Generic;
+#if NET472
+using Umbraco.Core;
+using Umbraco.Core.Deploy;
+using Umbraco.Core.Models;
+using Umbraco.Core.PropertyEditors;
+using UmbConstants = Umbraco.Core.Constants;
+#else
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Deploy;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Extensions;
+using UmbConstants = Umbraco.Cms.Core.Constants;
+#endif
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    internal sealed class NotesConfigurationConnector : IDataTypeConfigurationConnector
+    {
+#if NET472 == false
+        private readonly IConfigurationEditorJsonSerializer _configurationEditorJsonSerializer;
+#endif
+        private readonly ILocalLinkParser _localLinkParser;
+        private readonly IImageSourceParser _imageSourceParser;
+        private readonly IMacroParser _macroParser;
+
+        public IEnumerable<string> PropertyEditorAliases => new[] { NotesDataEditor.DataEditorName };
+
+        public NotesConfigurationConnector(
+#if NET472 == false
+            IConfigurationEditorJsonSerializer configurationEditorJsonSerializer,
+#endif
+            ILocalLinkParser localLinkParser,
+            IImageSourceParser imageSourceParser,
+            IMacroParser macroParser)
+        {
+#if NET472 == false
+            _configurationEditorJsonSerializer = configurationEditorJsonSerializer;
+#endif
+            _localLinkParser = localLinkParser;
+            _imageSourceParser = imageSourceParser;
+            _macroParser = macroParser;
+        }
+
+        public object FromArtifact(IDataType dataType, string configuration)
+        {
+            var dataTypeConfigurationEditor = dataType.Editor.GetConfigurationEditor();
+#if NET472
+            var db = dataTypeConfigurationEditor.FromDatabase(configuration);
+#else
+            var db = dataTypeConfigurationEditor.FromDatabase(configuration, _configurationEditorJsonSerializer);
+#endif
+
+            if (db is Dictionary<string, object> config &&
+                config.TryGetValueAs(NotesConfigurationField.Notes, out string notes) == true &&
+                string.IsNullOrWhiteSpace(notes) == false)
+            {
+                notes = _localLinkParser.FromArtifact(notes);
+                notes = _imageSourceParser.FromArtifact(notes);
+                notes = _macroParser.FromArtifact(notes);
+
+                config[NotesConfigurationField.Notes] = notes;
+
+                return config;
+            }
+
+            return db;
+        }
+
+        public string ToArtifact(IDataType dataType, ICollection<ArtifactDependency> dependencies)
+        {
+            if (dataType.Configuration is Dictionary<string, object> config &&
+                config.TryGetValueAs(NotesConfigurationField.Notes, out string notes) == true &&
+                string.IsNullOrWhiteSpace(notes) == false)
+            {
+                var udis = new List<Udi>();
+
+                notes = _localLinkParser.ToArtifact(notes, udis);
+                notes = _imageSourceParser.ToArtifact(notes, udis);
+                notes = _macroParser.ToArtifact(notes, udis);
+
+                foreach (var udi in udis)
+                {
+                    var mode = udi.EntityType == UmbConstants.UdiEntityType.Macro
+                        ? ArtifactDependencyMode.Match
+                        : ArtifactDependencyMode.Exist;
+
+                    dependencies.Add(new ArtifactDependency(udi, false, mode));
+                }
+
+                config[NotesConfigurationField.Notes] = notes;
+            }
+
+#if NET472
+            return ConfigurationEditor.ToDatabase(dataType.Configuration);
+#else
+            return ConfigurationEditor.ToDatabase(dataType.Configuration, _configurationEditorJsonSerializer);
+#endif
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/RenderMacro/RenderMacroConfigurationConnector.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/RenderMacro/RenderMacroConfigurationConnector.cs
@@ -1,0 +1,67 @@
+﻿/* Copyright © 2022 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+#if NET472
+using Umbraco.Core;
+using Umbraco.Core.Deploy;
+using Umbraco.Core.Models;
+using Umbraco.Core.PropertyEditors;
+#else
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Deploy;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Extensions;
+#endif
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    internal sealed class RenderMacroConfigurationConnector : IDataTypeConfigurationConnector
+    {
+        public IEnumerable<string> PropertyEditorAliases => new[] { RenderMacroDataEditor.DataEditorName };
+
+#if NET472 == false
+        private readonly IConfigurationEditorJsonSerializer _configurationEditorJsonSerializer;
+
+        public RenderMacroConfigurationConnector(IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
+        {
+            _configurationEditorJsonSerializer = configurationEditorJsonSerializer;
+        }
+#endif
+
+        public object FromArtifact(IDataType dataType, string configuration)
+        {
+            var dataTypeConfigurationEditor = dataType.Editor.GetConfigurationEditor();
+
+#if NET472
+            return dataTypeConfigurationEditor.FromDatabase(configuration);
+#else
+            return dataTypeConfigurationEditor.FromDatabase(configuration, _configurationEditorJsonSerializer);
+#endif
+        }
+
+        public string ToArtifact(IDataType dataType, ICollection<ArtifactDependency> dependencies)
+        {
+            if (dataType.Configuration is Dictionary<string, object> config &&
+                config.TryGetValueAs(RenderMacroConfigurationEditor.Macro, out JArray array) == true &&
+                array.Count > 0 &&
+                array[0] is JObject obj &&
+                obj.ContainsKey("udi") == true &&
+                UdiParser.TryParse(obj.Value<string>("udi"), out Udi udi) == true)
+            {
+                dependencies.Add(new ArtifactDependency(udi, false, ArtifactDependencyMode.Match));
+            }
+
+#if NET472
+            return ConfigurationEditor.ToDatabase(dataType.Configuration);
+#else
+            return ConfigurationEditor.ToDatabase(dataType.Configuration, _configurationEditorJsonSerializer);
+#endif
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/Polyfill/UdiParser.cs
+++ b/src/Umbraco.Community.Contentment/Polyfill/UdiParser.cs
@@ -11,6 +11,11 @@ namespace Umbraco.Core
     [EditorBrowsable(EditorBrowsableState.Never)]
     internal sealed class UdiParser
     {
+        public static bool TryParse(string s, out Udi udi)
+        {
+            return Udi.TryParse(s, out udi);
+        }
+
         public static bool TryParse(string s, out GuidUdi udi)
         {
             return GuidUdi.TryParse(s, out udi);


### PR DESCRIPTION
### Description

Added [Umbraco Deploy Value Connectors](https://our.umbraco.com/documentation/Add-ons/Umbraco-Deploy/Extending/#value-connectors) for the Notes, Editor Notes and RenderMacro editors.

This code will support adding any relevant artifact dependencies from the data-type configuration of these editors. e.g. with Notes if you add a Media item, or with RenderMacro - the Macro itself.

### Types of changes

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
