### PR TITLE
Create an abstract base class for Umbraco Content Data List Sources

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/BaseUmbracoDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/BaseUmbracoDataListSource.cs
@@ -1,23 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 #if NET472
-using Umbraco.Core;
-using Umbraco.Core.IO;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.PropertyEditors;
-using Umbraco.Core.Services;
 using Umbraco.Web;
-using UmbConstants = Umbraco.Core.Constants;
 #else
-using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors;
-using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Extensions;
-using UmbConstants = Umbraco.Cms.Core.Constants;
 #endif
 
 namespace Umbraco.Community.Contentment.DataEditors

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/BaseUmbracoDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/BaseUmbracoDataListSource.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+
+#if NET472
+using Umbraco.Core;
+using Umbraco.Core.IO;
+using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.Services;
+using Umbraco.Web;
+using UmbConstants = Umbraco.Core.Constants;
+#else
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Web;
+using Umbraco.Extensions;
+using UmbConstants = Umbraco.Cms.Core.Constants;
+#endif
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    public abstract class BaseUmbracoContentDataListSource : IDataListSource
+    {
+        private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+
+#if NET472
+        public BaseUmbracoContentDataListSource(
+            IUmbracoContextAccessor umbracoContextAccessor)
+        {
+            _umbracoContextAccessor = umbracoContextAccessor;
+
+        }
+#else
+        private readonly IRequestAccessor _requestAccessor;
+
+        public BaseUmbracoContentDataListSource(
+            IRequestAccessor requestAccessor,
+            IUmbracoContextAccessor umbracoContextAccessor)
+        {
+            _requestAccessor = requestAccessor;
+            _umbracoContextAccessor = umbracoContextAccessor;
+                   
+        }
+#endif
+
+
+        protected int? ContextContentId
+        {
+            get
+            {
+                var umbracoContext = _umbracoContextAccessor.GetRequiredUmbracoContext();
+                isContextContentParent = false;
+
+                // NOTE: First we check for "id" (if on a content page), then "parentId" (if editing an element).
+#if NET472
+                if (int.TryParse(umbracoContext.HttpContext.Request.QueryString.Get("id"), out var currentId) == true)
+#else
+                if (int.TryParse(_requestAccessor.GetQueryStringValue("id"), out var currentId) == true)
+#endif
+                {
+                    return currentId;
+                }
+#if NET472
+                else if (int.TryParse(umbracoContext.HttpContext.Request.QueryString.Get("parentId"), out var parentId) == true)
+#else
+                else if (int.TryParse(_requestAccessor.GetQueryStringValue("parentId"), out var parentId) == true)
+#endif
+                {
+                    isContextContentParent = true;
+                    return parentId;
+                }
+
+                return default(int?);
+            }
+        }
+
+        protected IPublishedContent GetContextContent()
+        {
+            var umbracoContext = _umbracoContextAccessor.GetRequiredUmbracoContext();
+            if (ContextContentId.HasValue == false || umbracoContext == null)
+            {
+                return null;
+            }
+
+            return umbracoContext.Content.GetById(true, ContextContentId.Value);
+        }
+
+        private bool isContextContentParent;
+        protected bool IsContextContentParent
+        {
+            get
+            {
+                return ContextContentId.HasValue && isContextContentParent;
+            }
+        }
+
+
+        public abstract Dictionary<string, object> DefaultValues { get; }
+
+        public abstract IEnumerable<ConfigurationField> Fields { get; }
+
+        public virtual string Group { get; } = Constants.Conventions.DataSourceGroups.Umbraco;
+
+        public abstract OverlaySize OverlaySize { get; }
+
+        public abstract string Name { get; }
+
+        public abstract string Description { get; }
+
+        public abstract string Icon { get; }
+
+        public abstract IEnumerable<DataListItem> GetItems(Dictionary<string, object> config);
+    }
+}


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->

### Description

When I create custom data list sources, I often find myself copying and pasting the querystring sniffing from your existing implementations. I also almost always go and get the IPublishedContent afterwards. 

A base class would remove the need for repeating the  querystring sniffing every time you want to do anything related to Umbraco Content.

Docs changes to follow, if you think this is worthwhile and in its current form.

<!-- Please include a summary of the change and which issue is fixed.
     Please also include relevant motivation and context.
     List any dependencies that are required for this change. -->

### Related Issues?

<!-- If suggesting a new feature or change, please discuss it in an issue first.
     If fixing a bug for an existing issue, please link to the issue here: -->

Sorry, I did not open a discussion or issue first as I already had the base class used in my own solutions. I also modified the existing implementations to use the base class as a demonstration. I'm happy to make any modifications to my existing code, but thought a PR may be the easiest way to illustrate my point.

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
     Please do not upgrade any NuGet dependencies.
     Please do not modify any licensing information, e.g. do not update the copyright year. -->

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [x] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
