### PR TITLE
Added missing translations for Danish

### DIFF
--- a/src/Umbraco.Community.Contentment/Web/UI/App_Plugins/Contentment/Lang/da.xml
+++ b/src/Umbraco.Community.Contentment/Web/UI/App_Plugins/Contentment/Lang/da.xml
@@ -11,6 +11,10 @@
         <key alias="removeItemMessage">Er du sikker på, at du vil fjerne denne element?</key>
         <key alias="removeItemButton">Ja, fjern</key>
 
+        <!-- Configuration Editor -->
+        <key alias="missingItemName">Dette element er ikke længere tilgængeligt</key>
+        <key alias="missingItemDescription">Fjern venligst konfigurationen og vælg et andet element.</key>
+
         <!-- Content Blocks -->
         <key alias="configureDisplayMode">Vælg og konfigurer en visningstype</key>
         <key alias="configureElementType">Vælg og konfigurer en elementtype</key>


### PR DESCRIPTION
### Description

I didn't see your call for localization, but I just saw that you pushed a new release, and went to check the Danish translations. Luckily Chriztian already translated most of the phrases, but there were two phrases missing, so here's a PR for those.

The English phrases refers to the same thing as _configurations_ and _items_, which might be a little wrong. But to align with this, I've used the same for the Danish translations, albeit _element_ instead of _item_ to also align with Chriztian's translations (which makes sense as _item_ doesn't have a direct translation).

![image](https://user-images.githubusercontent.com/3634580/196189639-56549b50-0532-49b7-996e-53a3b3efad53.png)

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
     Please do not upgrade any NuGet dependencies.
     Please do not modify any licensing information, e.g. do not update the copyright year. -->

Not sure translations fall in to one of the four categories, but _new feature_ might be the best match.

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
