### PR TITLE
Added `Group` property to `TimeZoneDataSource` example

### DIFF
--- a/docs/editors/data-list.md
+++ b/docs/editors/data-list.md
@@ -86,6 +86,8 @@ public class TimeZoneDataSource : IDataListSource
 
     public string Icon => "icon-globe";
 
+    public string Group => "Custom";
+
     public OverlaySize OverlaySize => OverlaySize.Small;
 
     public Dictionary<string, object> DefaultValues => default;


### PR DESCRIPTION
### Description

When I tested for https://github.com/leekelleher/umbraco-contentment/pull/273 I noticed that the `TimeZoneDataSource` example in the data list docs breaks as the `IDataListSource` now also requires a `Group` property to be implemented - so I've updated the example accordingly.

<!-- Please include a summary of the change and which issue is fixed.
     Please also include relevant motivation and context.
     List any dependencies that are required for this change. -->

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
     Please do not upgrade any NuGet dependencies.
     Please do not modify any licensing information, e.g. do not update the copyright year. -->

- [x] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
