### PR TITLE
Removes `sealed` modifier from `DataListItem` class

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataListItem.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataListItem.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Community.Contentment.DataEditors
     [JsonObject(
         ItemNullValueHandling = NullValueHandling.Ignore,
         NamingStrategyType = typeof(CamelCaseNamingStrategy))]
-    public sealed class DataListItem
+    public class DataListItem
     {
         public string Description { get; set; }
 


### PR DESCRIPTION
### Description

As discussed in #279 

Removed `sealed` modifier from `DataListItem`.

### Related Issues?

#279

### Types of changes

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
