### PR TITLE
Make CodeEditorDataEditor and NumberInputDataEditor public so that they are accessible with UmbracoBuilder.DataEditors().Exclude<T>()

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/CodeEditor/CodeEditorDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/CodeEditor/CodeEditorDataEditor.cs
@@ -30,7 +30,7 @@ namespace Umbraco.Community.Contentment.DataEditors
         ValueType = ValueTypes.Text,
         Group = Constants.Conventions.PropertyGroups.Code,
         Icon = DataEditorIcon)]
-    internal sealed class CodeEditorDataEditor : DataEditor
+    public sealed class CodeEditorDataEditor : DataEditor
     {
         internal const string DataEditorAlias = Constants.Internals.DataEditorAliasPrefix + "CodeEditor";
         internal const string DataEditorName = Constants.Internals.DataEditorNamePrefix + "Code Editor";

--- a/src/Umbraco.Community.Contentment/DataEditors/NumberInput/NumberInputDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/NumberInput/NumberInputDataEditor.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Community.Contentment.DataEditors
         ValueType = ValueTypes.Integer,
         Group = UmbConstants.PropertyEditors.Groups.Common,
         Icon = DataEditorIcon)]
-    internal sealed class NumberInputDataEditor : DataEditor
+    public sealed class NumberInputDataEditor : DataEditor
     {
         internal const string DataEditorAlias = Constants.Internals.DataEditorAliasPrefix + "NumberInput";
         internal const string DataEditorName = Constants.Internals.DataEditorNamePrefix + "Number Input";


### PR DESCRIPTION
### Description

Currently, it is impossible to exclude the `CodeEditorDataEditor` and the `NumberInputDataEditor` from Umbraco during startup seamlessly as both data editors are internal to the package and thus cannot be used as a generic type for the `.Exclude<T>()` call.

Most of the other editors can be excluded; thus, it would be nice if this was the case for these two data editors.

The context of the change is the need only to use a select few Data Editors from the package by doing the following during startup. As indicated, it is not fully compatible with the package yet:

```csharp
builder.UmbracoBuilder.DataEditors()
    .Exclude<BytesDataEditor>()
    //.Exclude<CodeEditorDataEditor>() is impossible due to its protection level.
    .Exclude<ContentBlocksDataEditor>()
    .Exclude<IconPickerDataEditor>()
    .Exclude<NotesDataEditor>()
    //.Exclude<NumberInputDataEditor>() is impossible due to its protection level.
    .Exclude<RenderMacroDataEditor>()
    .Exclude<TextInputDataEditor>();
```

### Types of changes

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [x] My change requires a change to the documentation.
- [x] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
