### PR TITLE
Fixes build for paths with spaces

### DIFF
--- a/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
+++ b/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
@@ -43,7 +43,7 @@
   </Target>
 
   <Target Name="ContentmentPrepareAssets" AfterTargets="PreBuildEvent" Condition="'$(TargetFramework)' == 'net7.0'">
-    <Exec Command="powershell -NoProfile -ExecutionPolicy RemoteSigned -file $(ProjectDir)..\..\build\build-assets.ps1 -ProjectDir $(ProjectDir)" />
+    <Exec Command="powershell -NoProfile -ExecutionPolicy RemoteSigned -file &quot;$(ProjectDir)..\..\build\build-assets.ps1&quot; -ProjectDir &quot;$(ProjectDir)\&quot;" />
   </Target>
 
 </Project>


### PR DESCRIPTION
When I forked the project and tried a local build I has issues due to the fact that I had spaces in the path to my folder.

Simple PR that just adds `&quot;` around the paths to solve this - now my local build i working.

### Types of changes
Build fix

- [x] Build fix =D

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [x] My change requires a change to the documentation.
- [x] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
