### PR TITLE
Adds info about DataListItem attribute

### DIFF
--- a/docs/data-sources/data-source--enum.md
+++ b/docs/data-sources/data-source--enum.md
@@ -22,3 +22,41 @@ Select the desired enumeration, by selecting the containing .NET assembly, and t
 The value returned from the List editor is the configured enumeration type.
 
 Depending on the `List editor` used, this may be wrapped in a `List<T>`.
+
+##### Controlling Enum display in Contentment
+
+Here's the proofread version of the text:
+
+You can use the [DataListItemAttribute](../../src/Umbraco.Community.Contentment/DataEditors/DataList/DataListItemAttribute.cs) to decorate your enum values with additional information for use with Contentment. With this attribute, you can specify properties such as name, description, icon, etc., for individual enum items.
+
+For example:
+
+```csharp
+using Umbraco.Community.Contentment.DataEditors;
+
+public enum MyEnum
+{
+    [DataListItem(Description = "This is the first value", Group = "Group A", Icon = "icon-first")]
+    First,
+
+    [DataListItem(Description = "This is the second value", Group = "Group B", Icon = "icon-second")]
+    Second,
+
+    [DataListItem(Description = "This is the third value", Group = "Group A", Icon = "icon-third")]
+    Third
+}
+```
+
+The `DataListItemAttribute` contains the following properties:
+
+| Property    | Description                                                      | Type    |
+|-------------|------------------------------------------------------------------|---------|
+| Description | Provides a description for the Enum value                         | string  |
+| Disabled    | Specifies whether the Enum value should be disabled               | bool    |
+| Group       | Assigns the Enum value to a specific group                        | string  |
+| Icon        | Specifies an icon for the Enum value                              | string  |
+| Ignore      | Indicates whether the Enum value should be ignored                | bool    |
+| Name        | Provides a custom name for the Enum value (default: field name)   | string  |
+| Value       | Specifies a custom value for the Enum value (default: field value)| string  |
+
+The provided text has been proofread and revised for clarity and accuracy.

--- a/docs/data-sources/data-source--enum.md
+++ b/docs/data-sources/data-source--enum.md
@@ -23,9 +23,7 @@ The value returned from the List editor is the configured enumeration type.
 
 Depending on the `List editor` used, this may be wrapped in a `List<T>`.
 
-##### Controlling Enum display in Contentment
-
-Here's the proofread version of the text:
+##### Controlling Enum display
 
 You can use the [DataListItemAttribute](../../src/Umbraco.Community.Contentment/DataEditors/DataList/DataListItemAttribute.cs) to decorate your enum values with additional information for use with Contentment. With this attribute, you can specify properties such as name, description, icon, etc., for individual enum items.
 
@@ -59,4 +57,3 @@ The `DataListItemAttribute` contains the following properties:
 | Name        | Provides a custom name for the Enum value (default: field name)   | string  |
 | Value       | Specifies a custom value for the Enum value (default: field value)| string  |
 
-The provided text has been proofread and revised for clarity and accuracy.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

### Description

I needed a way to extend the information about enums in data lists, and found it in the source code. So why not add some documentation? :)

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
     Please do not upgrade any NuGet dependencies.
     Please do not modify any licensing information, e.g. do not update the copyright year. -->

- [x] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My code follows the coding style of this project.
- [ ] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [x] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
