### PR TITLE
Made the umbraco content properties order by name

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentPropertiesDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentPropertiesDataListSource.cs
@@ -115,7 +115,7 @@ namespace Umbraco.Community.Contentment.DataEditors
                             Icon = _icons.ContainsKey(x.PropertyEditorAlias) == true
                                 ? _icons[x.PropertyEditorAlias]
                                 : UmbConstants.Icons.PropertyEditor,
-                        });
+                        }).OrderBy(y => y.Name);
                 }
             }
 

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentPropertiesDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentPropertiesDataListSource.cs
@@ -80,6 +80,20 @@ namespace Umbraco.Community.Contentment.DataEditors
                             { Constants.Conventions.ConfigurationFieldAliases.OverlayView, _ioHelper.ResolveRelativeOrVirtualUrl(ItemPickerDataListEditor.DataEditorOverlayViewPath) },
                             { MaxItemsConfigurationField.MaxItems, 1 },
                         }
+                    },
+                    new ConfigurationField
+                    {
+                        Key = "sortAlphabetically",
+                        Name = "Sort alphabetically?",
+                        Description = "Select to sort the properties in alphabetical order.<br>By default, the order is defined by the order they appear on the document type.",
+                        View = "boolean"
+                    },
+                    new ConfigurationField
+                    {
+                        Key = "includeNameProperty",
+                        Name = "Include Name Property?",
+                        Description = "Select to include the name property in the list of properties.",
+                        View = "boolean"
                     }
                 };
             }
@@ -105,7 +119,7 @@ namespace Umbraco.Community.Contentment.DataEditors
                         _icons = _dataEditors.Value.ToDictionary(x => x.Alias, x => x.Icon);
                     }
 
-                    return contentType
+                    var dataListItems = contentType
                         .CompositionPropertyTypes
                         .Select(x => new DataListItem
                         {
@@ -115,7 +129,29 @@ namespace Umbraco.Community.Contentment.DataEditors
                             Icon = _icons.ContainsKey(x.PropertyEditorAlias) == true
                                 ? _icons[x.PropertyEditorAlias]
                                 : UmbConstants.Icons.PropertyEditor,
-                        }).OrderBy(y => y.Name);
+                        });
+
+                    if (config.TryGetValueAs("includeNameProperty", out bool includeName) == true && includeName == true)
+                    {
+                        var tempDataListItems = dataListItems.ToList();
+                        tempDataListItems.Add(
+                            new DataListItem
+                            {
+                                Name = "Name",
+                                Value = "name",
+                                Description = "The name of the Umbraco content item",
+                                Icon = "icon-autofill"
+                            }
+                        );
+                        dataListItems = tempDataListItems;
+                    }
+
+                    if (config.TryGetValueAs("sortAlphabetically", out bool sortAlphabetically) == true && sortAlphabetically == true)
+                    {
+                        return dataListItems.OrderBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase);
+                    }
+
+                    return dataListItems;
                 }
             }
 


### PR DESCRIPTION
This change makes the Umbraco Content Properties Data List Source order by name to make the result much more usable.

As you can see, when not ordered alphabetically they are all over the place:

![image](https://github.com/leekelleher/umbraco-contentment/assets/9142936/cc7d2eb4-f75d-4e49-b915-3ba6162100fe)