### PR TITLE
Content Blocks - Remove items from value that cannot be selected

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/content-blocks.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/content-blocks.js
@@ -71,6 +71,9 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
                 config.nameTemplates[blockType.key] = $interpolate(blockType.nameTemplate || "Item {{ $index }}");
             });
 
+            // Remove items from the original value that can't be used (anymore)
+            $scope.model.value = $scope.model.value.filter(item => config.elementTypeLookup[item.elementType] !== undefined);
+
             vm.addButtonLabelKey = config.addButtonLabelKey || "grid_addElement";
             vm.displayMode = config.displayMode;
 


### PR DESCRIPTION
### Description

I added some code in the `init()` function that removes invalid/old values. It doesn't make sense to keep values that are not allowed anymore as defined in the datatype. As a result, the property editor is visible again and the console error isn't.

### Related Issues?

https://github.com/leekelleher/umbraco-contentment/issues/346

### Types of changes

Changed the 

- [ ] Documentation change
- [x] Bug fix #346 
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [ ] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
