### PR TITLE
Added `id` property to `package.manifest` file

### DIFF
--- a/src/Umbraco.Community.Contentment/Web/UI/App_Plugins/Contentment/package.manifest
+++ b/src/Umbraco.Community.Contentment/Web/UI/App_Plugins/Contentment/package.manifest
@@ -1,5 +1,6 @@
 ﻿{
     "name": "Contentment",
+    "id": "Umbraco.Community.Contentment",
     "version": "4.5.0-develop",
     "css": [ "~/App_Plugins/Contentment/contentment.css" ],
     "javascript": [ "~/App_Plugins/Contentment/contentment.js" ]


### PR DESCRIPTION
Umbraco 12 allows specifying an `id` property in package manifest files to indicate the ID of the NuGet package a given manifest is associated with. Here is the description from the JSON schema:

> The (NuGet) package ID, shown in the backoffice and included in package telemetry as unique identifier (supported in v12+). Also used to retrieve the assembly informational version if no explicit `version` and `versionAssemlbyName` is set.

The ID is used by Umbraco's telemetry, and also visible in the Packages section:

![image](https://github.com/leekelleher/umbraco-contentment/assets/3634580/79099631-a317-4996-a4c3-f55e6466b686)

I noticed that Contentment doesn't specify this property, so I thought I might as well add it.

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
     Please do not upgrade any NuGet dependencies.
     Please do not modify any licensing information, e.g. do not update the copyright year. -->

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [x] Other

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
