### PR TITLE
Data List - Umbraco Dictionary Item data-source: fixes parent selection

### DIFF
--- a/src/Umbraco.Cms.12.x/uSync/v9/DataTypes/ContentmentDataListUmbracoDictionaryItems.config
+++ b/src/Umbraco.Cms.12.x/uSync/v9/DataTypes/ContentmentDataListUmbracoDictionaryItems.config
@@ -13,7 +13,7 @@
       "value": {
         "item": [
           {
-            "id": "1",
+            "key": "6087c17e-726e-4ec6-aece-ad2bc3de6088",
             "name": "Labels"
           }
         ]

--- a/src/Umbraco.Cms.8.x/uSync/v8/DataTypes/ContentmentDataListUmbracoDictionaryItems.config
+++ b/src/Umbraco.Cms.8.x/uSync/v8/DataTypes/ContentmentDataListUmbracoDictionaryItems.config
@@ -13,7 +13,7 @@
       "value": {
         "item": [
           {
-            "id": "1",
+            "key": "6087c17e-726e-4ec6-aece-ad2bc3de6088",
             "name": "Labels"
           }
         ]

--- a/src/Umbraco.Community.Contentment/DataEditors/DictionaryPicker/dictionary-picker.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/DictionaryPicker/dictionary-picker.js
@@ -5,9 +5,9 @@
 
 angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.DictionaryPicker.Controller", [
     "$scope",
-    "entityResource",
+    "dictionaryResource",
     "editorService",
-    function ($scope, entityResource, editorService) {
+    function ($scope, dictionaryResource, editorService) {
 
         // console.log("dictionary-picker.model", $scope.model);
 
@@ -48,16 +48,18 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
                 title: "Dictionary item",
                 emptyStateMessage: "No dictionary items to choose from",
                 select: function (model) {
+                    dictionaryResource.getById(model.id).then(function (item) {
 
-                    $scope.model.value.push({ id: model.id, name: model.name });
+                        $scope.model.value.push({ key: item.key, name: item.name });
 
-                    if ((config.maxItems !== 0 && config.maxItems !== "0") && $scope.model.value.length >= config.maxItems) {
-                        vm.allowAdd = false;
-                    }
+                        if ((config.maxItems !== 0 && config.maxItems !== "0") && $scope.model.value.length >= config.maxItems) {
+                            vm.allowAdd = false;
+                        }
 
-                    setDirty();
+                        setDirty();
 
-                    editorService.close();
+                        editorService.close();
+                    });
                 },
                 close: function (model) {
                     editorService.close();


### PR DESCRIPTION
### Description

With the Umbraco Dictionary Item data-source, the ID of the selected parent dictionary item would change between each CMS environment. This patch changes the parent dictionary item to use the `Guid`/key instead of the `int`/ID.

The change has been made to be backwards-compatible with existing data/configurations.

Fixes #345.

### Related Issues?

- #345

### Types of changes

- [ ] Documentation change
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
