### PR TITLE
Update CopyContentmentPackageAssets target to run BeforeBuild

### DIFF
--- a/build/_nuget-post-install.targets
+++ b/build/_nuget-post-install.targets
@@ -13,7 +13,7 @@
         <ContentmentPackageContentFilesPath>$(MSBuildThisFileDirectory)..\content\App_Plugins\Contentment\**\*.*</ContentmentPackageContentFilesPath>
     </PropertyGroup>
 
-    <Target Name="CopyContentmentPackageAssets" BeforeTargets="Build">
+    <Target Name="CopyContentmentPackageAssets" BeforeTargets="BeforeBuild">
         <ItemGroup>
             <ContentmentPackageContentFiles Include="$(ContentmentPackageContentFilesPath)" />
         </ItemGroup>

--- a/build/_vs-copy-assets.targets
+++ b/build/_vs-copy-assets.targets
@@ -8,7 +8,7 @@
         <ContentmentPackageContentFilesPath>$(MSBuildThisFileDirectory)assets\App_Plugins\Contentment\**\*.*</ContentmentPackageContentFilesPath>
     </PropertyGroup>
 
-    <Target Name="CopyContentmentPackageAssets" BeforeTargets="Build">
+    <Target Name="CopyContentmentPackageAssets" BeforeTargets="BeforeBuild">
         <ItemGroup>
             <ContentmentPackageContentFiles Include="$(ContentmentPackageContentFilesPath)" />
         </ItemGroup>


### PR DESCRIPTION
### Description

This ensure package consumers don't need to do a `dotnet build` before `dotnet publish` to have the package assets properly copied to the output

This issue was initially present on the Umbraco Package template, but has since been fixed in https://github.com/umbraco/Umbraco-CMS/pull/11992

#### Workaround
Currently package consumers have to either:
- Have separate `build` and `publish` steps
- Add the following target to their `.csproj`:
```xml
<Target Name="EnsureCopyPackageAssets" BeforeTargets="BeforeBuild">
   <CallTarget Targets="CopyContentmentPackageAssets" />
</Target>
```

This issue is also is also present in previous versions, so might be worth backporting the fix.

### Steps to reproduce
Install the package
Make sure the project is in a clean state and the assets aren't present in App_Plugins yet (dotnet clean)
Run dotnet publish
The output should now be missing the package assets

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
     Please do not upgrade any NuGet dependencies.
     Please do not modify any licensing information, e.g. do not update the copyright year. -->

- [ ] Documentation change
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
