### PR TITLE
Include ability to sort content alphabetically in umbraco content data list source

### DIFF
--- a/src/Umbraco.Cms.10.x/uSync/v10/DataTypes/ContentmentDataListUmbracoContent.config
+++ b/src/Umbraco.Cms.10.x/uSync/v10/DataTypes/ContentmentDataListUmbracoContent.config
@@ -11,7 +11,8 @@
     {
       "key": "Umbraco.Community.Contentment.DataEditors.UmbracoContentDataListSource, Umbraco.Community.Contentment",
       "value": {
-        "parentNode": "umb://document/9772aed63d82474e9269f7f4c5504992"
+        "parentNode": "umb://document/9772aed63d82474e9269f7f4c5504992",
+        "sortAlphabetically": "0"
       }
     }
   ],

--- a/src/Umbraco.Cms.10.x/uSync/v10/DataTypes/ContentmentDataPickerUmbracoContent.config
+++ b/src/Umbraco.Cms.10.x/uSync/v10/DataTypes/ContentmentDataPickerUmbracoContent.config
@@ -11,7 +11,8 @@
     {
       "key": "Umbraco.Community.Contentment.DataEditors.UmbracoContentDataListSource, Umbraco.Community.Contentment",
       "value": {
-        "parentNode": "umb://document/7c6bcf13fa7d4949b975ffb331ee0dcc"
+        "parentNode": "umb://document/7c6bcf13fa7d4949b975ffb331ee0dcc",
+        "sortAlphabetically": "1"
       }
     }
   ],

--- a/src/Umbraco.Cms.12.x/uSync/v9/DataTypes/ContentmentDataListUmbracoContent.config
+++ b/src/Umbraco.Cms.12.x/uSync/v9/DataTypes/ContentmentDataListUmbracoContent.config
@@ -11,7 +11,8 @@
     {
       "key": "Umbraco.Community.Contentment.DataEditors.UmbracoContentDataListSource, Umbraco.Community.Contentment",
       "value": {
-        "parentNode": "umb://document/9772aed63d82474e9269f7f4c5504992"
+        "parentNode": "umb://document/9772aed63d82474e9269f7f4c5504992",
+        "sortAlphabetically": "0"
       }
     }
   ],

--- a/src/Umbraco.Cms.12.x/uSync/v9/DataTypes/ContentmentDataPickerUmbracoContent.config
+++ b/src/Umbraco.Cms.12.x/uSync/v9/DataTypes/ContentmentDataPickerUmbracoContent.config
@@ -11,7 +11,8 @@
     {
       "key": "Umbraco.Community.Contentment.DataEditors.UmbracoContentDataListSource, Umbraco.Community.Contentment",
       "value": {
-        "parentNode": "umb://document/7c6bcf13fa7d4949b975ffb331ee0dcc"
+        "parentNode": "umb://document/7c6bcf13fa7d4949b975ffb331ee0dcc",
+        "sortAlphabetically": "1"
       }
     }
   ],

--- a/src/Umbraco.Cms.8.x/uSync/v8/DataTypes/ContentmentDataListUmbracoContent.config
+++ b/src/Umbraco.Cms.8.x/uSync/v8/DataTypes/ContentmentDataListUmbracoContent.config
@@ -11,7 +11,8 @@
     {
       "key": "Umbraco.Community.Contentment.DataEditors.UmbracoContentDataListSource, Umbraco.Community.Contentment",
       "value": {
-        "parentNode": "umb://document/9772aed63d82474e9269f7f4c5504992"
+        "parentNode": "umb://document/9772aed63d82474e9269f7f4c5504992",
+        "sortAlphabetically": "0"
       }
     }
   ],

--- a/src/Umbraco.Cms.8.x/uSync/v8/DataTypes/ContentmentDataPickerUmbracoContent.config
+++ b/src/Umbraco.Cms.8.x/uSync/v8/DataTypes/ContentmentDataPickerUmbracoContent.config
@@ -11,7 +11,8 @@
     {
       "key": "Umbraco.Community.Contentment.DataEditors.UmbracoContentDataListSource, Umbraco.Community.Contentment",
       "value": {
-        "parentNode": "umb://document/7c6bcf13fa7d4949b975ffb331ee0dcc"
+        "parentNode": "umb://document/7c6bcf13fa7d4949b975ffb331ee0dcc",
+        "sortAlphabetically": "1"
       }
     }
   ],

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentDataListSource.cs
@@ -71,18 +71,18 @@ namespace Umbraco.Community.Contentment.DataEditors
             },
             new ConfigurationField
             {
+                Key = "imageAlias",
+                Name = "Image alias",
+                Description = $"When using the Cards display mode, you can set a thumbnail image by enter the property alias of the media picker. The default alias is '{_defaultImageAlias}'.",
+                View =  "textstring",
+            },
+            new ConfigurationField
+            {
                 Key = "sortAlphabetically",
                 Name = "Sort alphabetically?",
                 Description = "Select to sort the content items in alphabetical order.<br>By default, the order is defined by the Umbraco content sort order.",
                 View = "boolean"
             },
-            new ConfigurationField
-            {
-                Key = "imageAlias",
-                Name = "Image alias",
-                Description = $"When using the Cards display mode, you can set a thumbnail image by enter the property alias of the media picker. The default alias is '{_defaultImageAlias}'.",
-                View =  "textstring",
-            }
         };
 
         public string Group => Constants.Conventions.DataSourceGroups.Umbraco;

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentDataListSource.cs
@@ -117,18 +117,12 @@ namespace Umbraco.Community.Contentment.DataEditors
                 var preview = true;
                 var imageAlias = config.GetValueAs("imageAlias", _defaultImageAlias);
 
-                var items = values
+                return Task.FromResult(values
                     .Select(x => UdiParser.TryParse(x, out GuidUdi udi) == true ? udi : null)
                     .WhereNotNull()
                     .Select(x => umbracoContext.Content.GetById(preview, x))
-                    .WhereNotNull();
-
-                if (config.TryGetValueAs("sortAlphabetically", out bool sortAlphabetically) == true && sortAlphabetically == true)
-                {
-                    items = items.OrderBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase);
-                }
-
-                return Task.FromResult(items.Select(x => ToDataListItem(x, imageAlias)));
+                    .WhereNotNull()
+                    .Select(x => ToDataListItem(x, imageAlias)));
             }
 
             return Task.FromResult(Enumerable.Empty<DataListItem>());


### PR DESCRIPTION
When using the Umbraco Content Data List Source the order of the items is just whatever the sort order is and sometimes that can look messy, especially when used in a picker.

![image](https://github.com/leekelleher/umbraco-contentment/assets/9142936/04206ff5-3f7c-4b72-8dd9-c00fd64a7bb5)

### Description

This PR adds a Sort Alphabetically toggle so you can do exactly what it says.

![image](https://github.com/leekelleher/umbraco-contentment/assets/9142936/f5dd5e0d-a0fa-43c9-95d4-2c92d41fb09f)

Which results in the following:

![image](https://github.com/leekelleher/umbraco-contentment/assets/9142936/7e7a91df-4cb9-4303-ae69-3d758ab36278)

### Related Issues?

No

### Types of changes

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
