### PR TITLE
Avoid hardcoding the SQL provider names

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/SqlDataListSource.NET6_0.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/SqlDataListSource.NET6_0.cs
@@ -6,7 +6,6 @@
 /* NOTE: This code file is ONLY for Umbraco v10/v11/v12, .NET Core 6.0/7.0. */
 
 #if NET6_0_OR_GREATER
-
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Hosting;

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/SqlDataListSource.NET6_0.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/SqlDataListSource.NET6_0.cs
@@ -6,6 +6,7 @@
 /* NOTE: This code file is ONLY for Umbraco v10/v11/v12, .NET Core 6.0/7.0. */
 
 #if NET6_0_OR_GREATER
+
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Hosting;
@@ -35,7 +36,7 @@ namespace Umbraco.Community.Contentment.DataEditors
             IScopeProvider scopeProvider,
             IIOHelper ioHelper)
         {
-            // NOTE: Umbraco doesn't ship with SqlServer mode, so we check if its been added manually, otherwise defautls to Razor.
+            // NOTE: Umbraco doesn't ship with SqlServer mode, so we check if its been added manually, otherwise defaults to Razor.
             _codeEditorMode = webHostEnvironment.WebPathExists("~/umbraco/lib/ace-builds/src-min-noconflict/mode-sqlserver.js") == true
                 ? "sqlserver"
                 : "razor";
@@ -113,12 +114,12 @@ namespace Umbraco.Community.Contentment.DataEditors
 
                 if (string.IsNullOrWhiteSpace(providerName) == true)
                 {
-                    providerName = "Microsoft.Data.SqlClient";
+                    providerName = Umbraco.Cms.Persistence.SqlServer.Constants.ProviderName;
                 }
 
                 var dbProviderFactory = _dbProviderFactoryCreator.CreateFactory(providerName);
 
-                if (providerName.InvariantEquals("Microsoft.Data.Sqlite") == true)
+                if (providerName.InvariantEquals(Umbraco.Cms.Persistence.Sqlite.Constants.ProviderName) == true)
                 {
                     return new Database(connectionString, DatabaseType.SQLite, dbProviderFactory);
                 }

--- a/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
+++ b/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
@@ -27,6 +27,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Umbraco.Cms.Persistence.Sqlite" Version="10.0.0" />
+    <PackageReference Include="Umbraco.Cms.Persistence.SqlServer" Version="10.0.0" />
     <PackageReference Include="Umbraco.Cms.Web.Website" Version="10.0.0" />
     <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="10.0.0" />
   </ItemGroup>


### PR DESCRIPTION
As [noted on Discord](https://discord-chats.umbraco.com/t/15985291/query-custom-database-separate-to-umbraco-with-raw-sql#f7b4c1b1-01f7-4063-97be-7b70ec86e4bb) you were looking for a constant for database provider names. This implements that (and also fixes a spelling error in a comment). 

### Description

I did have to add NuGet references in order to get this to work and I understand you want to keep those very minimal. So feel free to close this immediately! 😁 

For what it's worth: the only reason for HQ to change those strings is if:

a) We were no longer using them (will eventually happen with the switch to EF Core completely I'd think) 
b) Microsoft changed the names of those libraries

### Related Issues?

https://discord-chats.umbraco.com/t/15985291/query-custom-database-separate-to-umbraco-with-raw-sql#f7b4c1b1-01f7-4063-97be-7b70ec86e4bb

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
     Please do not upgrade any NuGet dependencies.
     Please do not modify any licensing information, e.g. do not update the copyright year. -->

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
