### PR TITLE
Added "Rich Text Editor"

### DIFF
--- a/src/Umbraco.Community.Contentment/Constants.cs
+++ b/src/Umbraco.Community.Contentment/Constants.cs
@@ -82,7 +82,9 @@ namespace Umbraco.Community.Contentment
                         "numlist",
                         "link",
                         "umbmediapicker",
+#if NET8_0_OR_GREATER == false
                         "umbmacro",
+#endif
                         "umbembeddialog"
                     },
                 };

--- a/src/Umbraco.Community.Contentment/DataEditors/EditorNotes/EditorNotesConfigurationEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/EditorNotes/EditorNotesConfigurationEditor.cs
@@ -71,36 +71,14 @@ namespace Umbraco.Community.Contentment.DataEditors
                 Key = Message,
                 Name = nameof(Message),
                 Description = "Enter the notes to be displayed for the content editor.",
+#if NET8_0_OR_GREATER
+                View = ioHelper.ResolveRelativeOrVirtualUrl(RichTextEditorDataEditor.DataEditorViewPath),
+#else
                 View = ioHelper.ResolveRelativeOrVirtualUrl("~/umbraco/views/propertyeditors/rte/rte.html"),
+#endif
                 Config = new Dictionary<string, object>
                 {
-                    { "editor", new
-                        {
-                            maxImageSize = 500,
-                            mode = "classic",
-                            stylesheets = false,
-                            toolbar = new[]
-                            {
-                                "ace",
-                                "undo",
-                                "redo",
-                                "cut",
-                                "styleselect",
-                                "removeformat",
-                                "bold",
-                                "italic",
-                                "alignleft",
-                                "aligncenter",
-                                "alignright",
-                                "bullist",
-                                "numlist",
-                                "link",
-                                "umbmediapicker",
-                                "umbmacro",
-                                "umbembeddialog"
-                            },
-                        }
-                    }
+                    { "editor", Constants.Conventions.DefaultConfiguration.RichTextEditor }
                 }
             });
 

--- a/src/Umbraco.Community.Contentment/DataEditors/Notes/NotesConfigurationEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/Notes/NotesConfigurationEditor.cs
@@ -27,7 +27,11 @@ namespace Umbraco.Community.Contentment.DataEditors
                 Key = Notes,
                 Name = nameof(Notes),
                 Description = "Enter the notes to be displayed for the content editor.",
+#if NET8_0_OR_GREATER
+                View = ioHelper.ResolveRelativeOrVirtualUrl(RichTextEditorDataEditor.DataEditorViewPath),
+#else
                 View = ioHelper.ResolveRelativeOrVirtualUrl("~/umbraco/views/propertyeditors/rte/rte.html"),
+#endif
                 Config = new Dictionary<string, object>
                 {
                     { "editor", Constants.Conventions.DefaultConfiguration.RichTextEditor }

--- a/src/Umbraco.Community.Contentment/DataEditors/RichTextEditor/README.md
+++ b/src/Umbraco.Community.Contentment/DataEditors/RichTextEditor/README.md
@@ -1,0 +1,11 @@
+﻿## Rich Text Editor
+
+### Used interally by
+
+This Rich Text Editor is intended to exclusively used by Notes and Editor Notes configuration editors.
+
+Umbraco v13 introduced a breaking-change, due to the inclusion of the Inline Blocks feature (replacing inline Macros).
+https://github.com/umbraco/Umbraco-CMS/pull/15029/files#diff-429a0a5b9fe236b792a692145f07d5aef201f4eaeae1b321f0dd5d698577f8ebR433
+
+In order to workaround this breaking-change and maintain support for the Notes and Editor Notes editors,
+this Rich Text Editor will only work with Umbraco v13 and does not support the Inline Blocks feature.

--- a/src/Umbraco.Community.Contentment/DataEditors/RichTextEditor/RichTextEditorDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/RichTextEditor/RichTextEditorDataEditor.cs
@@ -1,0 +1,12 @@
+﻿/* Copyright © 2023 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    internal sealed class RichTextEditorDataEditor
+    {
+        internal const string DataEditorViewPath = Constants.Internals.EditorsPathRoot + "rich-text-editor.html";
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/RichTextEditor/rich-text-editor.html
+++ b/src/Umbraco.Community.Contentment/DataEditors/RichTextEditor/rich-text-editor.html
@@ -1,0 +1,32 @@
+﻿<!-- Copyright © 2013-present Umbraco.
+   - Parts of this Source Code have been derived from Umbraco CMS.
+   - https://github.com/umbraco/Umbraco-CMS/blob/release-13.0.0-rc5/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/umb-rte-property-editor.html
+   - Modified under the permissions of the MIT License.
+   - Modifications are licensed under the Mozilla Public License.
+   - Copyright © 2023 Lee Kelleher.
+   - This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+<div ng-controller="Umbraco.Community.Contentment.DataEditors.RichTextEditor.Controller as vm"
+     class="umb-property-editor umb-rte"
+     ng-class="{'--initialized': !vm.loading}">
+
+    <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
+
+    <ng-form name="rteForm">
+        <div class="umb-rte-editor-con">
+            <input type="text"
+                   id="{{vm.model.alias}}"
+                   ng-focus="vm.focusRTE()"
+                   name="modelValue"
+                   ng-model="vm.model.value"
+                   style="position:absolute;top:0;width:0;height:0;padding:0;border:none;" />
+            <div disable-hotkeys
+                 id="{{vm.textAreaHtmlId}}"
+                 class="umb-rte-editor"
+                 ng-style="{ width: vm.containerWidth, height: vm.containerHeight, overflow: vm.containerOverflow}">
+            </div>
+        </div>
+    </ng-form>
+</div>

--- a/src/Umbraco.Community.Contentment/DataEditors/RichTextEditor/rich-text-editor.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/RichTextEditor/rich-text-editor.js
@@ -1,0 +1,253 @@
+﻿/* Copyright © 2013-present Umbraco.
+ * Parts of this Source Code have been derived from Umbraco CMS.
+ * https://github.com/umbraco/Umbraco-CMS/blob/release-13.0.0-rc5/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.component.js
+ * Modified under the permissions of the MIT License.
+ * Modifications are licensed under the Mozilla Public License.
+ * Copyright © 2030 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.RichTextEditor.Controller", [
+    "$element",
+    "$scope",
+    "$q",
+    "$timeout",
+    "assetsService",
+    "tinyMceAssets",
+    "tinyMceService",
+    function ($element, $scope, $q, $timeout, assetsService, tinyMceAssets, tinyMceService) {
+
+        if ($scope.model.hasOwnProperty("contentTypeId")) {
+            // NOTE: This will prevents the editor attempting to load whilst in the Content Type Editor's property preview panel.
+            return;
+        }
+
+        //console.log("rich-text-editor.model", $scope.model);
+
+        var defaultConfig = {};
+        var config = Object.assign({}, defaultConfig, $scope.model.config);
+
+        var vm = this;
+
+        function init() {
+
+            vm.model = $scope.model;
+
+            var unsubscribe = [];
+            var modelObject;
+
+            vm.readonly = false;
+            vm.tinyMceEditor = null;
+
+            vm.loading = true;
+            vm.rteLoading = true;
+            vm.updateLoading = function () {
+                if (!vm.rteLoading) {
+                    vm.loading = false;
+                }
+            }
+
+            vm.$onInit = function () {
+
+                // set the onValueChanged callback, this will tell us if the block list model changed on the server
+                // once the data is submitted. If so we need to re-initialize
+                vm.model.onValueChanged = onServerValueChanged;
+
+                vm.listWrapperStyles = {};
+
+                if (vm.model.config.maxPropertyWidth) {
+                    vm.listWrapperStyles["max-width"] = vm.model.config.maxPropertyWidth;
+                }
+
+
+                // ******************** //
+                // RTE PART:
+                // ******************** //
+
+
+                // To id the html textarea we need to use the datetime ticks because we can have multiple rte's per a single property alias
+                // because now we have to support having 2x (maybe more at some stage) content editors being displayed at once. This is because
+                // we have this mini content editor panel that can be launched with MNTP.
+                vm.textAreaHtmlId = vm.model.alias + "_" + String.CreateGuid();
+
+                var editorConfig = vm.model.config ? vm.model.config.editor : null;
+                if (!editorConfig || Utilities.isString(editorConfig)) {
+                    editorConfig = tinyMceService.defaultPrevalues();
+                }
+
+                var width = editorConfig.dimensions ? parseInt(editorConfig.dimensions.width, 10) || null : null;
+                var height = editorConfig.dimensions ? parseInt(editorConfig.dimensions.height, 10) || null : null;
+
+                vm.containerWidth = "auto";
+                vm.containerHeight = "auto";
+                vm.containerOverflow = "inherit";
+
+                var promises = [];
+
+                //queue file loading
+                tinyMceAssets.forEach(function (tinyJsAsset) {
+                    promises.push(assetsService.loadJs(tinyJsAsset, $scope));
+                });
+
+                promises.push(tinyMceService.getTinyMceEditorConfig({
+                    htmlId: vm.textAreaHtmlId,
+                    stylesheets: editorConfig.stylesheets,
+                    toolbar: editorConfig.toolbar,
+                    mode: editorConfig.mode
+                }));
+
+                //wait for queue to end
+                $q.all(promises).then(function (result) {
+
+                    var standardConfig = result[promises.length - 1];
+
+                    if (height !== null) {
+                        standardConfig.plugins.splice(standardConfig.plugins.indexOf("autoresize"), 1);
+                    }
+
+                    //create a baseline Config to extend upon
+                    var baseLineConfigObj = {
+                        maxImageSize: editorConfig.maxImageSize,
+                        width: width,
+                        height: height
+                    };
+
+                    baseLineConfigObj.setup = function (editor) {
+
+                        //set the reference
+                        vm.tinyMceEditor = editor;
+
+                        vm.tinyMceEditor.on("init", function (e) {
+                            $timeout(function () {
+                                vm.rteLoading = false;
+                                vm.updateLoading();
+                            });
+                        });
+                        vm.tinyMceEditor.on("focus", function () {
+                            $element[0].dispatchEvent(new CustomEvent("umb-rte-focus", { composed: true, bubbles: true }));
+                        });
+                        vm.tinyMceEditor.on("blur", function () {
+                            $element[0].dispatchEvent(new CustomEvent("umb-rte-blur", { composed: true, bubbles: true }));
+                        });
+
+                        //initialize the standard editor functionality for Umbraco
+                        tinyMceService.initializeEditor({
+                            //scope: $scope,
+                            editor: editor,
+                            toolbar: editorConfig.toolbar,
+                            model: vm.model,
+                            getValue: function () {
+                                return vm.model.value;
+                            },
+                            setValue: function (newVal) {
+                                vm.model.value = newVal;
+                                $scope.$evalAsync();
+                            },
+                            culture: null,
+                            segment: null,
+                            blockEditorApi: {},
+                            parentForm: vm.propertyForm,
+                            valFormManager: vm.valFormManager,
+                            currentFormInput: $scope.rteForm.modelValue
+                        });
+
+                    };
+
+                    Utilities.extend(baseLineConfigObj, standardConfig);
+
+                    // Readonly mode
+                    baseLineConfigObj.toolbar = vm.readonly ? false : baseLineConfigObj.toolbar;
+                    baseLineConfigObj.readonly = vm.readonly ? 1 : baseLineConfigObj.readonly;
+
+                    // We need to wait for DOM to have rendered before we can find the element by ID.
+                    $timeout(function () {
+                        tinymce.init(baseLineConfigObj);
+                    }, 50);
+
+                    //listen for formSubmitting event (the result is callback used to remove the event subscription)
+                    unsubscribe.push($scope.$on("formSubmitting", function () {
+                        if (vm.tinyMceEditor != null && !vm.rteLoading) {
+
+                            // Remove Angular Classes from markup:
+                            var parser = new DOMParser();
+                            var doc = parser.parseFromString(vm.model.value, "text/html");
+
+                            // Get all elements in the parsed document
+                            var elements = doc.querySelectorAll("*[class]");
+                            elements.forEach(element => {
+                                var classAttribute = element.getAttribute("class");
+                                if (classAttribute) {
+                                    // Split the class attribute by spaces and remove "ng-scope" and "ng-isolate-scope"
+                                    var classes = classAttribute.split(" ");
+                                    var newClasses = classes.filter(function (className) {
+                                        return className !== "ng-scope" && className !== "ng-isolate-scope";
+                                    });
+
+                                    // Update the class attribute with the remaining classes
+                                    if (newClasses.length > 0) {
+                                        element.setAttribute("class", newClasses.join(" "));
+                                    } else {
+                                        // If no remaining classes, remove the class attribute
+                                        element.removeAttribute("class");
+                                    }
+                                }
+                            });
+
+                            vm.model.value = doc.body.innerHTML;
+
+                        }
+                    }));
+
+                    vm.focusRTE = function () {
+                        vm.tinyMceEditor.focus();
+                    }
+
+                    // When the element is disposed we need to unsubscribe!
+                    // NOTE: this is very important otherwise if this is part of a modal, the listener still exists because the dom
+                    // element might still be there even after the modal has been hidden.
+                    $scope.$on("$destroy", function () {
+                        if (vm.tinyMceEditor != null) {
+                            if ($element && $element[0]) {
+                                $element[0].dispatchEvent(new CustomEvent("blur", { composed: true, bubbles: true }));
+                            }
+                            vm.tinyMceEditor.destroy();
+                            vm.tinyMceEditor = null;
+                        }
+                    });
+
+                });
+
+            };
+
+            // Called when we save the value, the server may return an updated data and our value is re-synced
+            // we need to deal with that here so that our model values are all in sync so we basically re-initialize.
+            function onServerValueChanged(newVal, oldVal) {
+                onLoaded();
+            }
+
+            function setDirty() {
+                if (vm.propertyForm) {
+                    vm.propertyForm.$setDirty();
+                }
+            }
+
+            function onLoaded() {
+
+                vm.updateLoading();
+
+                $scope.$evalAsync();
+
+            }
+
+            $scope.$on("$destroy", function () {
+                for (const subscription of unsubscribe) {
+                    subscription();
+                }
+            });
+
+        };
+
+        init();
+    }
+]);


### PR DESCRIPTION
### Description

This **Rich Text Editor** is intended to exclusively used by **Notes** and **Editor Notes** configuration editors.

Umbraco v13 introduced a breaking-change, due to the inclusion of the Inline Blocks feature (replacing inline Macros).
https://github.com/umbraco/Umbraco-CMS/pull/15029/files#diff-429a0a5b9fe236b792a692145f07d5aef201f4eaeae1b321f0dd5d698577f8ebR433

In order to workaround this breaking-change and maintain support for the Notes and Editor Notes editors, this Rich Text Editor will only work with Umbraco v13 and does not support the Inline Blocks feature.

### Types of changes

- [ ] Documentation change
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
