### PR TITLE
`ContentmentConstants`: Publicly expose certain internal constants

### DIFF
--- a/src/Umbraco.Community.Contentment/Constants.cs
+++ b/src/Umbraco.Community.Contentment/Constants.cs
@@ -9,29 +9,31 @@ namespace Umbraco.Community.Contentment
     {
         internal static partial class Internals
         {
-            internal const string ProjectName = "Contentment";
+            internal const string ProjectName = nameof(Contentment);
 
             internal const string ProjectAlias = "contentment";
 
-            internal const string ProjectNamespace = "Umbraco.Community.Contentment";
+            internal const string ProjectNamespace = $"{nameof(Umbraco)}.{nameof(Community)}.{nameof(Contentment)}";
 
-            internal const string DataEditorNamePrefix = "[" + ProjectName + "] ";
+            internal const string DataEditorNamePrefix = $"[{ProjectName}] ";
 
-            internal const string DataEditorAliasPrefix = ProjectNamespace + ".";
+            internal const string DataEditorAliasPrefix = $"{ProjectNamespace}.";
 
-            internal const string EditorsPathRoot = PackagePathRoot + "editors/";
+            internal const string EditorsPathRoot = $"{PackagePathRoot}editors/";
 
-            internal const string PackagePathRoot = "/App_Plugins/" + ProjectName + "/";
+            internal const string PackagePathRoot = $"{UmbConstants.SystemDirectories.AppPlugins}/{ProjectName}/";
 
             internal const string PluginControllerName = ProjectName;
 
-            internal const string BackOfficePathRoot = PackagePathRoot + "backoffice/" + TreeAlias + "/";
+            internal const string BackOfficePathRoot = $"{PackagePathRoot}backoffice/{TreeAlias}/";
 
             internal const string TreeAlias = ProjectAlias;
 
-            internal const string ConfigurationSection = "Umbraco:Contentment";
+            internal const string ConfigurationSection = $"{nameof(Umbraco)}:{nameof(Contentment)}";
 
-            internal const string EmptyEditorViewPath = EditorsPathRoot + "_empty.html";
+            internal const string EmptyEditorViewPath = $"{EditorsPathRoot}_empty.html";
+
+            public const string RepositoryUrl = "https://github.com/leekelleher/umbraco-contentment";
         }
 
         internal static partial class Conventions
@@ -107,14 +109,9 @@ namespace Umbraco.Community.Contentment
 
         internal static partial class Icons
         {
-            public const string Contentment = "icon-contentment";
+            public const string Contentment = $"icon-{Internals.ProjectAlias}";
 
             public const string ContentTemplate = "icon-blueprint";
-        }
-
-        internal static partial class Package
-        {
-            public const string RepositoryUrl = "https://github.com/leekelleher/umbraco-contentment";
         }
 
         internal static partial class Values

--- a/src/Umbraco.Community.Contentment/ContentmentConstants.cs
+++ b/src/Umbraco.Community.Contentment/ContentmentConstants.cs
@@ -1,0 +1,126 @@
+/* Copyright © 2023 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+namespace Umbraco.Community.Contentment;
+
+public static class ContentmentConstants
+{
+    public static class PropertyEditors
+    {
+        public static class Aliases
+        {
+            public const string Bytes = DataEditors.BytesDataEditor.DataEditorAlias;
+
+            public const string CodeEditor = DataEditors.CodeEditorDataEditor.DataEditorAlias;
+
+            public const string ConfigurationEditor = DataEditors.ConfigurationEditorDataEditor.DataEditorAlias;
+
+            public const string ContentBlocks = DataEditors.ContentBlocksDataEditor.DataEditorAlias;
+
+            public const string DataList = DataEditors.DataListDataEditor.DataEditorAlias;
+
+            public const string DataPicker = DataEditors.DataPickerDataEditor.DataEditorAlias;
+
+            public const string DataTable = DataEditors.DataTableDataEditor.DataEditorAlias;
+
+            public const string EditorNotes = DataEditors.EditorNotesDataEditor.DataEditorAlias;
+
+            public const string IconPicker = DataEditors.IconPickerDataEditor.DataEditorAlias;
+
+            public const string ListItems = DataEditors.ListItemsDataEditor.DataEditorAlias;
+
+            public const string Notes = DataEditors.NotesDataEditor.DataEditorAlias;
+
+            public const string NumberInput = DataEditors.NumberInputDataEditor.DataEditorAlias;
+
+            public const string RenderMacro = DataEditors.RenderMacroDataEditor.DataEditorAlias;
+
+            public const string SocialLinks = DataEditors.SocialLinksDataEditor.DataEditorAlias;
+
+            public const string TemplatedLabel = DataEditors.TemplatedLabelDataEditor.DataEditorAlias;
+
+            public const string TextboxList = DataEditors.TextboxListDataEditor.DataEditorAlias;
+
+            public const string TextInput = DataEditors.TextInputDataEditor.DataEditorAlias;
+        }
+
+        public static class ConfigurationKeys
+        {
+            public const string AddButtonLabelKey = Constants.Conventions.ConfigurationFieldAliases.AddButtonLabelKey;
+
+            public const string DefaultValue = Constants.Conventions.ConfigurationFieldAliases.DefaultValue;
+
+            public const string Items = Constants.Conventions.ConfigurationFieldAliases.Items;
+
+            public const string OverlayView = Constants.Conventions.ConfigurationFieldAliases.OverlayView;
+        }
+
+        public static class Groups
+        {
+            public const string Code = Constants.Conventions.PropertyGroups.Code;
+
+            public const string Display = Constants.Conventions.PropertyGroups.Display;
+        }
+
+        public static class Views
+        {
+            public const string Buttons = DataEditors.ButtonsDataListEditor.DataEditorViewPath;
+
+            public const string Bytes = DataEditors.BytesDataEditor.DataEditorViewPath;
+
+            public const string CascadingDropdownList = DataEditors.CascadingDropdownListDataEditor.DataEditorViewPath;
+
+            public const string CheckboxList = DataEditors.ButtonsDataListEditor.DataEditorViewPath;
+
+            public const string CodeEditor = DataEditors.CodeEditorDataEditor.DataEditorViewPath;
+
+            public const string ConfigurationEditor = DataEditors.ConfigurationEditorDataEditor.DataEditorViewPath;
+
+            public const string ContentBlocks = DataEditors.ContentBlocksDataEditor.DataEditorViewPath;
+
+            public const string ContentPicker = DataEditors.ContentPickerDataEditor.DataEditorViewPath;
+
+            public const string DataList = DataEditors.DataListDataEditor.DataEditorViewPath;
+
+            public const string DataPicker = DataEditors.DataPickerDataEditor.DataEditorViewPath;
+
+            public const string DataTable = DataEditors.DataTableDataEditor.DataEditorViewPath;
+
+            public const string DictionaryPicker = DataEditors.DictionaryPickerDataEditor.DataEditorViewPath;
+
+            public const string DropdownList = DataEditors.DropdownListDataListEditor.DataEditorViewPath;
+
+            public const string EditorNotes = DataEditors.EditorNotesDataEditor.DataEditorViewPath;
+
+            public const string IconPicker = DataEditors.IconPickerDataEditor.DataEditorViewPath;
+
+            public const string ItemPicker = DataEditors.ItemPickerDataListEditor.DataEditorViewPath;
+
+            public const string ListItems = DataEditors.ListItemsDataEditor.DataEditorViewPath;
+
+            public const string MacroPicker = DataEditors.MacroPickerDataEditor.DataEditorViewPath;
+
+            public const string Notes = DataEditors.NotesDataEditor.DataEditorViewPath;
+
+            public const string NumberInput = DataEditors.NumberInputDataEditor.DataEditorViewPath;
+
+            public const string RadioButtonList = DataEditors.RadioButtonListDataListEditor.DataEditorViewPath;
+
+            public const string RenderMacro = DataEditors.RenderMacroDataEditor.DataEditorViewPath;
+
+            public const string SocialLinks = DataEditors.SocialLinksDataEditor.DataEditorViewPath;
+
+            public const string Tags = DataEditors.TagsDataListEditor.DataEditorViewPath;
+
+            public const string TemplatedLabel = DataEditors.TemplatedLabelDataEditor.DataEditorViewPath;
+
+            public const string TemplatedList = DataEditors.TemplatedListDataListEditor.DataEditorViewPath;
+
+            public const string TextboxList = DataEditors.TextboxListDataEditor.DataEditorViewPath;
+
+            public const string TextInput = DataEditors.TextInputDataEditor.DataEditorViewPath;
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/ContentmentManifestFilter.cs
+++ b/src/Umbraco.Community.Contentment/ContentmentManifestFilter.cs
@@ -15,10 +15,11 @@ internal sealed class ContentmentManifestFilter : IManifestFilter
         manifests.Add(new PackageManifest
         {
             AllowPackageTelemetry = true,
+            PackageId = Constants.Internals.ProjectNamespace,
             PackageName = Constants.Internals.ProjectName,
-            Scripts = new[] { Constants.Internals.PackagePathRoot + Constants.Internals.ProjectAlias + ".js" },
-            Stylesheets = new[] { Constants.Internals.PackagePathRoot + Constants.Internals.ProjectAlias + ".css" },
-            Version = ContentmentVersion.SemanticVersion?.ToSemanticStringWithoutBuild() ?? "5.0.0",
+            Scripts = [$"{Constants.Internals.PackagePathRoot}{Constants.Internals.ProjectAlias}.js"],
+            Stylesheets = [$"{Constants.Internals.PackagePathRoot}{Constants.Internals.ProjectAlias}.css"],
+            Version = ContentmentVersion.SemanticVersion?.ToSemanticStringWithoutBuild() ?? "0.0.0",
         });
     }
 }

--- a/src/Umbraco.Community.Contentment/DataEditors/ContentPicker/ContentPickerDataEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentPicker/ContentPickerDataEditor.cs
@@ -7,6 +7,6 @@ namespace Umbraco.Community.Contentment.DataEditors
 {
     internal sealed class ContentPickerDataEditor
     {
-        internal const string DataEditorSourceViewPath = Constants.Internals.EditorsPathRoot + "content-source.html";
+        internal const string DataEditorViewPath = Constants.Internals.EditorsPathRoot + "content-source.html";
     }
 }

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataListConfigurationEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataListConfigurationEditor.cs
@@ -55,7 +55,7 @@ namespace Umbraco.Community.Contentment.DataEditors
                         @class = "alert alert-info",
                         title = "Do you need a custom data-source?",
                         notes = $@"<p>If one of the data-sources above does not fit your needs, you can extend Data List with your own custom data source.</p>
-<p>To do this, read the documentation on <a href=""{Constants.Package.RepositoryUrl}/blob/develop/docs/editors/data-list.md#extending-with-your-own-custom-data-source"" target=""_blank"" rel=""noopener""><strong>extending with your own custom data source</strong></a>.</p>" } },
+<p>To do this, read the documentation on <a href=""{Constants.Internals.RepositoryUrl}/blob/develop/docs/editors/data-list.md#extending-with-your-own-custom-data-source"" target=""_blank"" rel=""noopener""><strong>extending with your own custom data source</strong></a>.</p>" } },
                 }
             });
 

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/JsonDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/JsonDataListSource.cs
@@ -47,7 +47,7 @@ namespace Umbraco.Community.Contentment.DataEditors
 <p>This data-source uses Newtonsoft's Json.NET library, with this we are limited to extracting only the 'value' from any key/value-pairs.</p>
 <p>If you need assistance with JSONPath syntax, please refer to this resource: <a href=""https://goessner.net/articles/JsonPath/"" target=""_blank""><strong>goessner.net/articles/JsonPath</strong></a>.</p>
 <hr>
-<p><em>If you are a developer and have ideas on how to extract the <code>key</code> (name) from the items, please do let me know on <a href=""{Constants.Package.RepositoryUrl}/issues/40"" target=""_blank""><strong>GitHub issue: #40</strong></a>.</em></p>
+<p><em>If you are a developer and have ideas on how to extract the <code>key</code> (name) from the items, please do let me know on <a href=""{Constants.Internals.RepositoryUrl}/issues/40"" target=""_blank""><strong>GitHub issue: #40</strong></a>.</em></p>
 </details>", true),
             new ConfigurationField
             {

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentDataListSource.cs
@@ -52,7 +52,7 @@ namespace Umbraco.Community.Contentment.DataEditors
                 Key = "parentNode",
                 Name = "Parent node",
                 Description = "Set a parent node to use its child nodes as the data source items.",
-                View =  _ioHelper.ResolveRelativeOrVirtualUrl(ContentPickerDataEditor.DataEditorSourceViewPath),
+                View =  _ioHelper.ResolveRelativeOrVirtualUrl(ContentPickerDataEditor.DataEditorViewPath),
             },
             new ConfigurationField
             {

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentPropertyValueDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentPropertyValueDataListSource.cs
@@ -57,7 +57,7 @@ namespace Umbraco.Community.Contentment.DataEditors.DataList.DataSources
                 Key = "contentNode",
                 Name = "Content node",
                 Description = "Set the content node to take the property value from.",
-                View =  _ioHelper.ResolveRelativeOrVirtualUrl(ContentPickerDataEditor.DataEditorSourceViewPath),
+                View =  _ioHelper.ResolveRelativeOrVirtualUrl(ContentPickerDataEditor.DataEditorViewPath),
             },
             new ConfigurationField
             {

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentXPathDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentXPathDataListSource.cs
@@ -63,7 +63,7 @@ namespace Umbraco.Community.Contentment.DataEditors
 <dd><code>$site</code> - ancestor page located at level 1.</dd>
 </dl>
 <hr />
-<p><strong>Please note,</strong> this data source will not work if used within a 'Nested Content' element type. <strong><em>This is a known issue.</em></strong> <a href=""{Constants.Package.RepositoryUrl}/issues/30#issuecomment-668684508"" target=""_blank"" rel=""noopener"">Please see GitHub issue #30 for details.</a></p>
+<p><strong>Please note,</strong> this data source will not work if used within a 'Nested Content' element type. <strong><em>This is a known issue.</em></strong> <a href=""{Constants.Internals.RepositoryUrl}/issues/30#issuecomment-668684508"" target=""_blank"" rel=""noopener"">Please see GitHub issue #30 for details.</a></p>
 </details>", true),
         };
 

--- a/src/Umbraco.Community.Contentment/DataEditors/TextboxList/TextboxListConfigurationEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/TextboxList/TextboxListConfigurationEditor.cs
@@ -44,7 +44,7 @@ namespace Umbraco.Community.Contentment.DataEditors
                         @class = "alert alert-info",
                         title = "Do you need a custom data-source?",
                         notes = $@"<p>If one of the data-sources above does not fit your needs, you can extend Data List with your own custom data source.</p>
-<p>To do this, read the documentation on <a href=""{Constants.Package.RepositoryUrl}/blob/develop/docs/editors/data-list.md#extending-with-your-own-custom-data-source"" target=""_blank"" rel=""noopener""><strong>extending with your own custom data source</strong></a>.</p>" } },
+<p>To do this, read the documentation on <a href=""{Constants.Internals.RepositoryUrl}/blob/develop/docs/editors/data-list.md#extending-with-your-own-custom-data-source"" target=""_blank"" rel=""noopener""><strong>extending with your own custom data source</strong></a>.</p>" } },
                 }
             });
 


### PR DESCRIPTION
### Description

Introduces `ContentmentConstants` façade class to publicly expose useful constants that were only available internally within Contentment.

The structure of the `ContentmentConstants` class will follow the same pattern as [Umbraco's `Constants` class](https://github.com/umbraco/Umbraco-CMS/blob/release-13.0.0/src/Umbraco.Core/Constants-PropertyEditors.cs).

### Related Issues?

- #362 

### Types of changes

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
