### PR TITLE
DataList: Umbraco Content: Adds Dynamic Root support

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/ContentPicker/content-source.html
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentPicker/content-source.html
@@ -1,4 +1,4 @@
-﻿<!-- Copyright © 2013-present Umbraco.
+<!-- Copyright © 2013-present Umbraco.
    - Parts of this Source Code have been derived from Umbraco CMS.
    - https://github.com/umbraco/Umbraco-CMS/blob/release-8.6.1/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.html
    - Modified under the permissions of the MIT License.
@@ -8,9 +8,18 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
 
-<div ng-controller="Umbraco.Community.Contentment.DataEditors.ContentSource.Controller as vm">
+<div ng-controller="Umbraco.Community.Contentment.DataEditors.ContentSource.Controller as vm" ng-switch="vm.type">
 
-    <div ng-show="vm.node">
+    <div ng-switch-default>
+        <umb-button-group button-style="[block]"
+                          default-button="vm.buttonGroup.defaultButton"
+                          sub-buttons="vm.buttonGroup.subButtons"
+                          direction="down"
+                          float="right">
+        </umb-button-group>
+    </div>
+
+    <div ng-switch-when="picker">
         <umb-load-indicator ng-show="vm.loading"></umb-load-indicator>
         <umb-node-preview ng-hide="vm.loading"
                           name="vm.node.name"
@@ -18,64 +27,80 @@
                           description="vm.node.path"
                           published="vm.node.published"
                           allow-remove="true"
-                          on-remove="vm.remove()">
+                          on-remove="vm.clearValue()">
         </umb-node-preview>
     </div>
 
-    <div ng-if="!vm.node">
-
-        <div ng-hide="vm.showSearch || model.value">
-            <umb-button type="button"
-                        button-style="[action,block]"
-                        action="vm.pick()"
-                        label-key="general_choose"
-                        add-ellipsis="true">
-            </umb-button>
-            <umb-button type="button"
-                        button-style="link"
-                        action="vm.show()"
-                        class="mt2"
-                        icon="icon-search"
-                        label="Query for start node with XPath">
-            </umb-button>
+    <div ng-switch-when="dynamicRoot">
+        <umb-node-preview single
+                          icon="vm.dynamicRoot.origin.icon"
+                          name="vm.dynamicRoot.origin.name"
+                          description="vm.dynamicRoot.origin.description"
+                          allow-change="true"
+                          allow-remove="false"
+                          on-change="vm.openOrigin()">
+        </umb-node-preview>
+        <div ng-if="vm.dynamicRoot.steps" ui-sortable="vm.sortableOptions" ng-model="model.value.querySteps">
+            <umb-node-preview ng-repeat="step in vm.dynamicRoot.steps track by $id(step)"
+                              single
+                              class="mt1"
+                              icon="step.icon"
+                              name="step.name"
+                              description="step.description"
+                              allow-edit="false"
+                              allow-remove="true"
+                              on-remove="vm.removeQueryStep($index, step)">
+            </umb-node-preview>
         </div>
+        <button type="button"
+                class="umb-node-preview-add mt1"
+                ng-click="vm.openQueryStep()">
+            <localize key="dynamicRoot_addQueryStep">Add query step</localize>
+        </button>
+        <umb-button type="button"
+                    button-style="link"
+                    action="vm.clearValue()"
+                    icon="icon-delete"
+                    label-key="dynamicRoot_cancelAndClearQuery">
+        </umb-button>
+    </div>
 
-        <div ng-show="vm.showSearch || model.value">
+    <div ng-switch-when="xpath">
 
-            <input ng-model="model.value"
-                   type="text"
-                   class="umb-property-editor umb-textstring"
-                   placeholder="Enter XPath query..."
-                   spellcheck="false">
+        <input ng-model="model.value"
+               type="text"
+               class="umb-property-editor umb-textstring"
+               placeholder="Enter XPath query..."
+               umb-auto-focus="{{vm.type === 'xpath'}}"
+               spellcheck="false">
 
-            <div class="mt2">
-                <umb-button type="button"
-                            button-style="info"
-                            action="vm.help()"
-                            icon="icon-help-alt"
-                            label="Show XPath query help">
-                </umb-button>
-                <umb-button type="button"
-                            button-style="danger"
-                            action="vm.clear()"
-                            icon="icon-delete"
-                            label="Cancel and clear query">
-                </umb-button>
-                <div ng-show="vm.showHelp" class="alert alert-form mt3">
-                    <p>Use an XPath query to set a start page. For a context-aware query, you can use one of the pre-defined placeholders.</p>
-                    <p>Placeholders find the nearest published content ID and run the XPath query from there. For instance:</p>
-                    <pre><code>$site/newsListingPage</code></pre>
-                    <p>This query will try to get the current website page (at level 1), then find the first page of type `newsListingPage`.</p>
-                    <dl>
-                        <dt>Available placeholders:</dt>
-                        <dd><code>$current</code> - current page or closest ancestor.</dd>
-                        <dd><code>$parent</code> - parent page or closest ancestor.</dd>
-                        <dd><code>$root</code> - root page in the content tree.</dd>
-                        <dd><code>$site</code> - ancestor page located at level 1.</dd>
-                    </dl>
-                    <hr />
-                    <p><strong>Please note,</strong> when using an XPath query, this data source will not work if used within a 'Nested Content' element type. <strong><em>This is a known issue.</em></strong> <a href="https://github.com/leekelleher/umbraco-contentment/issues/30#issuecomment-668684508" target="_blank" rel="noopener">Please see GitHub issue #30 for details.</a></p>
-                </div>
+        <div class="mt2">
+            <umb-button type="button"
+                        button-style="info"
+                        action="vm.toggleXPathHelp()"
+                        icon="icon-help-alt"
+                        label="Show XPath query help">
+            </umb-button>
+            <umb-button type="button"
+                        button-style="danger"
+                        action="vm.clearValue()"
+                        icon="icon-delete"
+                        label="Cancel and clear query">
+            </umb-button>
+            <div ng-show="vm.showXPathHelp" class="alert alert-form mt3">
+                <p>Use an XPath query to set a start page. For a context-aware query, you can use one of the pre-defined placeholders.</p>
+                <p>Placeholders find the nearest published content ID and run the XPath query from there. For instance:</p>
+                <pre><code>$site/newsListingPage</code></pre>
+                <p>This query will try to get the current website page (at level 1), then find the first page of type `newsListingPage`.</p>
+                <dl>
+                    <dt>Available placeholders:</dt>
+                    <dd><code>$current</code> - current page or closest ancestor.</dd>
+                    <dd><code>$parent</code> - parent page or closest ancestor.</dd>
+                    <dd><code>$root</code> - root page in the content tree.</dd>
+                    <dd><code>$site</code> - ancestor page located at level 1.</dd>
+                </dl>
+                <hr />
+                <p><strong>Please note,</strong> when using an XPath query, this data source will not work if used within a 'Nested Content' element type. <strong><em>This is a known issue.</em></strong> <a href="https://github.com/leekelleher/umbraco-contentment/issues/30#issuecomment-668684508" target="_blank" rel="noopener">Please see GitHub issue #30 for details.</a></p>
             </div>
         </div>
 

--- a/src/Umbraco.Community.Contentment/DataEditors/ContentPicker/content-source.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentPicker/content-source.js
@@ -1,101 +1,234 @@
-﻿/* Copyright © 2020 Lee Kelleher.
+/* Copyright © 2020 Lee Kelleher.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.ContentSource.Controller", [
     "$scope",
+    "$controller",
+    "$q",
     "editorService",
     "entityResource",
-    function ($scope, editorService, entityResource) {
+    "localizationService",
+    function ($scope, $controller, $q, editorService, entityResource, localizationService) {
 
         //console.log("content-source.model", $scope.model);
 
-        var defaultConfig = {
-        };
-        var config = Object.assign({}, defaultConfig, $scope.model.config);
+        var config = Object.assign({}, $scope.model.config);
 
         var vm = this;
 
         function init() {
 
-            // NOTE: If it starts with "umb://" we assume it's an Umbraco UDI, otherwise it's an XPath.
-            if ($scope.model.value && $scope.model.value.startsWith("umb://document/")) {
+            vm.type = "select";
+
+            vm.dynamicRoot = null;
+            vm.node = null;
+
+            if (typeof $scope.model.value === 'string' && $scope.model.value.startsWith("umb://document/")) {
+                vm.type = "picker";
                 vm.node = {};
                 vm.loading = true;
                 entityResource.getById($scope.model.value, "Document").then(item => {
-                    populate(item);
+                    setPickerModel(item);
                     vm.loading = false;
                 })
-            } else {
-                vm.node = null;
+            } else if (typeof $scope.model.value === 'object' && $scope.model.value.hasOwnProperty("originAlias")) {
+                vm.type = "dynamicRoot";
+                setDynamicRootModel();
+            }
+            else {
+                vm.type = "xpath";
             }
 
-            vm.showHelp = false;
-            vm.showSearch = false;
+            vm.buttonGroup = {
+                defaultButton: { labelKey: "contentPicker_defineRootNode", handler: openPicker },
+                subButtons: [
+                    { labelKey: "contentPicker_defineDynamicRoot", handler: openOrigin },
+                    { labelKey: "contentPicker_defineXPathOrigin", handler: openXPath },
+                ]
+            };
 
-            vm.pick = pick;
-            vm.remove = remove;
+            vm.sortableOptions = {
+                axis: "y",
+                containment: "parent",
+                cursor: "move",
+                disabled: vm.allowSort === false,
+                opacity: 0.7,
+                scroll: true,
+                tolerance: "pointer",
+                update: function (e, ui) {
+                    setDynamicRootModel();
+                }
+            };
 
-            vm.show = show;
-            vm.hide = hide;
-
-            vm.help = help;
-            vm.clear = clear;
+            vm.clearValue = clearValue;
+            vm.openOrigin = openOrigin;
+            vm.openQueryStep = openQueryStep;
+            vm.removeQueryStep = removeQueryStep;
+            vm.showXPathHelp = false;
+            vm.toggleXPathHelp = toggleXPathHelp;
         };
 
-        function pick() {
+        function clearValue() {
+            vm.type = "select";
+            $scope.model.value = null;
+            vm.node = null;
+            vm.dynamicRoot = null;
+        };
 
+        function getIconForOriginAlias(originAlias) {
+            switch (originAlias) {
+                case "Root":
+                    return "icon-home";
+                case "Parent":
+                    return "icon-page-up";
+                case "Current":
+                    return "icon-document";
+                case "Site":
+                    return "icon-home";
+                case "ByKey":
+                    return "icon-wand";
+            }
+        }
+
+        function getIconForQueryStep(queryStep) {
+            switch (queryStep.alias) {
+                case "NearestAncestorOrSelf":
+                    return "icon-chevron-up";
+                case "FurthestAncestorOrSelf":
+                    return "icon-chevron-up";
+                case "NearestDescendantOrSelf":
+                    return "icon-chevron-down";
+                case "FurthestDescendantOrSelf":
+                    return "icon-chevron-down";
+            }
+            return "icon-lab";
+        }
+
+        function openPicker() {
             editorService.treePicker({
                 idType: "udi",
                 section: "content",
                 treeAlias: "content",
                 multiPicker: false,
-                submit: function submit(model) {
-
+                submit: function (model) {
+                    vm.type = "picker";
                     var item = model.selection[0];
-
-                    populate(item);
-
+                    setPickerModel(item);
                     $scope.model.value = item.udi;
-
                     editorService.close();
                 },
-                close: function close() {
+                close: function () {
                     editorService.close();
                 }
             });
-
         };
 
-        function remove() {
-            $scope.model.value = null;
-            vm.node = null;
+        function openOrigin() {
+            editorService.open({
+                view: "views/common/infiniteeditors/pickdynamicrootorigin/pickdynamicrootorigin.html",
+                contentType: "content",
+                size: "small",
+                value: {},
+                multiPicker: false,
+                submit: function (model) {
+                    vm.type = "dynamicRoot";
+                    $scope.model.value = Object.assign({}, $scope.model.value, model.value);
+                    setDynamicRootModel();
+                    editorService.close();
+                },
+                close: function () {
+                    editorService.close();
+                }
+            });
         };
 
-        function show() {
-            vm.showSearch = true;
+        function openQueryStep() {
+            editorService.open({
+                view: "views/common/infiniteeditors/pickdynamicrootquerystep/pickdynamicrootquerystep.html",
+                contentType: "content",
+                size: "small",
+                multiPicker: false,
+                submit: function (model) {
+                    if (!$scope.model.value.querySteps) {
+                        $scope.model.value.querySteps = [];
+                    }
+                    $scope.model.value.querySteps.push(model.value);
+                    setDynamicRootModel();
+                    editorService.close();
+                },
+                close: function () {
+                    editorService.close();
+                }
+            });
         };
 
-        function hide() {
-            vm.showSearch = false;
+        function openXPath() {
+            vm.type = "xpath";
         };
 
-        function help() {
-            vm.showHelp = !vm.showHelp;
-        }
-
-        function clear() {
-            vm.showSearch = false;
-            $scope.model.value = null;
+        function removeQueryStep($index, step) {
+            if ($index !== -1 && $scope.model.value.querySteps) {
+                $scope.model.value.querySteps.splice($index, 1);
+                setDynamicRootModel()
+            }
         };
 
-        function populate(item) {
+        function setDynamicRootModel() {
+            vm.dynamicRoot = {
+                origin: { icon: null, name: null, description: null },
+                steps: [],
+            };
+
+            const getDataForOrigin = (data) => {
+                const key = `dynamicRoot_origin${data.originAlias}Title`;
+                localizationService.localize(key).then(name => {
+                    vm.dynamicRoot.origin.name = name;
+                });
+
+                if (data.originKey) {
+                    entityResource.getById(data.originKey, "document").then(entity => {
+                        vm.dynamicRoot.origin.description = entity.name;
+                    });
+                }
+
+                vm.dynamicRoot.origin.icon = getIconForOriginAlias(data.originAlias);
+            };
+
+            const getDataForQueryStep = (queryStep) => {
+                const icon = getIconForQueryStep(queryStep);
+                const keys = [`dynamicRoot_queryStep${queryStep.alias}Title`, "dynamicRoot_queryStepTypes"];
+                localizationService.localizeMany(keys).then(values => {
+                    const name = values[0];
+                    const description = queryStep.anyOfDocTypeKeys && queryStep.anyOfDocTypeKeys.length > 0
+                        ? (values[1] || "That matches types: ") + queryStep.anyOfDocTypeKeys.join(", ")
+                        : null;
+                    vm.dynamicRoot.steps.push({ icon, name, description });
+                });
+            };
+
+            const promises = [];
+
+            promises.push(getDataForOrigin($scope.model.value));
+
+            if ($scope.model.value.querySteps) {
+                $scope.model.value.querySteps.forEach(x => promises.push(getDataForQueryStep(x)));
+            }
+
+            $q.all(promises);
+        };
+
+        function setPickerModel(item) {
             vm.node = item;
             entityResource.getUrl(item.id, "Document").then(data => {
                 vm.node.path = data;
             });
-        }
+        };
+
+        function toggleXPathHelp() {
+            vm.showXPathHelp = !vm.showXPathHelp;
+        };
 
         init();
     }


### PR DESCRIPTION
### Description

Adds Dynamic Root support to the Umbraco Content data-source for the Data List property-editor.


### Related Issues?

- #381 

### Types of changes

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [x] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
