### PR TITLE
Data List: Extends `ContentmentContentContext` to access `parentId` Form and JSON data

### DIFF
--- a/src/Umbraco.Community.Contentment/Composing/ContentmentComposer.cs
+++ b/src/Umbraco.Community.Contentment/Composing/ContentmentComposer.cs
@@ -1,12 +1,15 @@
-﻿/* Copyright © 2019 Lee Kelleher.
+/* Copyright © 2019 Lee Kelleher.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Web.Common.ApplicationBuilder;
 using Umbraco.Community.Contentment.DataEditors;
 using Umbraco.Community.Contentment.Notifications;
 using Umbraco.Community.Contentment.Services;
@@ -47,6 +50,20 @@ namespace Umbraco.Community.Contentment.Composing
                 .AddNotificationHandler<ServerVariablesParsingNotification, ContentmentServerVariablesParsingNotification>()
                 .AddNotificationHandler<UmbracoApplicationStartingNotification, ContentmentUmbracoApplicationStartingNotification>()
             ;
+
+            builder.Services.Configure<UmbracoPipelineOptions>(opts =>
+            {
+                opts.AddFilter(new UmbracoPipelineFilter("UmbBlockListGetEmptyByKeysRequest_EnableBuffering")
+                {
+                    // HACK:  [LK] To support `IContentmentContentContext` inside the BlockList editor,
+                    // we need to re-access the `Request.Body` to extract the `parentId` value.
+                    // The `GetEmptyByKeys` path has been hard-coded, as unsure how else to generate it at this stage.
+                    PrePipeline = app => app.UseWhen(
+                        ctx => ctx.Request.Path.StartsWithSegments("/umbraco/backoffice/umbracoapi/content/GetEmptyByKeys"),
+                        app2 => app2.Use(async (ctx, next) => { ctx.Request.EnableBuffering(); await next(ctx); })
+                    ),
+                });
+            });
         }
     }
 }

--- a/src/Umbraco.Community.Contentment/Services/ContentmentContentContext.cs
+++ b/src/Umbraco.Community.Contentment/Services/ContentmentContentContext.cs
@@ -35,11 +35,11 @@ namespace Umbraco.Community.Contentment.Services
             }
 
             // NOTE: First we check for "id" (if on a content page), then "parentId" (if editing an element).
-            if (int.TryParse(_requestAccessor.GetQueryStringValue("id"), out var currentId) == true)
+            if (int.TryParse(_requestAccessor.GetRequestValue("id"), out var currentId) == true)
             {
                 return currentId;
             }
-            else if (int.TryParse(_requestAccessor.GetQueryStringValue("parentId"), out var parentId) == true)
+            else if (int.TryParse(_requestAccessor.GetRequestValue("parentId"), out var parentId) == true)
             {
                 isParent = true;
 

--- a/src/Umbraco.Community.Contentment/Services/ContentmentContentContext.cs
+++ b/src/Umbraco.Community.Contentment/Services/ContentmentContentContext.cs
@@ -3,20 +3,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Web;
+using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.Services
 {
     public sealed class ContentmentContentContext : IContentmentContentContext
     {
+        private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IRequestAccessor _requestAccessor;
         private readonly IUmbracoContextAccessor _umbracoContextAccessor;
 
         public ContentmentContentContext(
+            IHttpContextAccessor httpContextAccessor,
             IRequestAccessor requestAccessor,
             IUmbracoContextAccessor umbracoContextAccessor)
         {
+            _httpContextAccessor = httpContextAccessor;
             _requestAccessor = requestAccessor;
             _umbracoContextAccessor = umbracoContextAccessor;
         }
@@ -44,6 +50,21 @@ namespace Umbraco.Community.Contentment.Services
                 isParent = true;
 
                 return parentId;
+            }
+
+            var json = _httpContextAccessor.HttpContext?.Request.GetRawBodyStringAsync().GetAwaiter().GetResult();
+            if (string.IsNullOrWhiteSpace(json) == false)
+            {
+                var obj = JsonConvert.DeserializeAnonymousType(json, new { id = 0, parentId = 0 });
+                if (obj?.id > 0)
+                {
+                    return obj.id;
+                }
+                else if (obj?.parentId > 0)
+                {
+                    isParent = true;
+                    return obj.parentId;
+                }
             }
 
             return default;


### PR DESCRIPTION
### Description

Transpires that the client-side patch I submitted for the BlockList editor (in https://github.com/umbraco/Umbraco-CMS/pull/15063), didn't work.  This is due to how `ContentmentContentContext` was trying to access the `id` and `parentId` parameters (on the querystring URL). However, the BlockList editor makes a POST request to the `GetEmptyByKeys()` endpoint, but not only that, the `parentId` is within a JSON blob sent in the body of the POST request. Which sounds fine, read the JSON from the request body and all good.

**Not so fast!** Turns out that in ASP.NET Core, the `Request.Body` can only be read once, which in the case of the `GetEmptyByKeys()` endpoint, that's done with the model-binding (of the `ContentTypesByKeys` type).

So to access the request body contents multiple times, you need to [enable `request.EnableBuffering()`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.httprequestrewindextensions.enablebuffering?view=aspnetcore-8.0).  From searching through Umbraco source, I found that there is an extension method called `GetRawBodyStringAsync()`, which even has [the `.EnableBuffering()` call in it](https://github.com/umbraco/Umbraco-CMS/blob/release-13.2.0/src/Umbraco.Web.Common/Extensions/HttpRequestExtensions.cs#L99), super, job done.

**Not so fast!** Turns out that `request.EnableBuffering()` must be done at app-startup. Now, I needed a way to add a middleware to configure the request buffering, but I didn't want to enable this for all request (as it's considered a small performance hit), so I wanted to have a conditional middleware for a specific route/path.

I found this blog post super helpful in figuring out how to do this:
<https://markb.uk/asp-net-core-read-raw-request-body-as-string.html>

TL,DR; Contentment adds a conditional middleware to the `GetEmptyByKeys()` API route to enable buffering of the request body contents, so that it can be accessed again during the request lifecycle.

Please note, that I have targeted this PR on (upcoming) Contentment v5, as it (currently) only relevant for the BlockList editor patch available in Umbraco v13.1.0. I do not intend to backport it to Contentment v4.6.x, that is, unless there is a good enough reason to do so.


### Related Issues?

- #388

### Types of changes

- [ ] Documentation change
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
