### PR TITLE
Content Blocks: Handle `JArray` data (typically when nested)

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlocksValueConverter.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlocksValueConverter.cs
@@ -50,7 +50,10 @@ namespace Umbraco.Community.Contentment.DataEditors
             {
                 return JsonConvert.DeserializeObject<IEnumerable<ContentBlock>>(value);
             }
-
+            else if (source is JArray jValue)
+            {
+                return JsonConvert.DeserializeObject<IEnumerable<ContentBlock>>(jValue.ToString());
+            }
             return base.ConvertSourceToIntermediate(owner, propertyType, source, preview);
         }
 

--- a/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlocksValueConverter.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlocksValueConverter.cs
@@ -5,7 +5,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Umbraco.Community.Contentment.Web.PublishedCache;
 #if NET472
 using Umbraco.Core;
@@ -50,10 +52,12 @@ namespace Umbraco.Community.Contentment.DataEditors
             {
                 return JsonConvert.DeserializeObject<IEnumerable<ContentBlock>>(value);
             }
-            else if (source is JArray jValue)
+
+            if (source is JArray array && array.Any() == true)
             {
-                return JsonConvert.DeserializeObject<IEnumerable<ContentBlock>>(jValue.ToString());
+                return array.ToObject<IEnumerable<ContentBlock>>();
             }
+
             return base.ConvertSourceToIntermediate(owner, propertyType, source, preview);
         }
 


### PR DESCRIPTION
### Description

Handle the 'sometimes' when the stored ContentBlock data appears as a JArray instead of a string

In some circumstances

eg when a ContentmentBlocks is nested inside the Core Umbraco BlockList 

(yes I know)

and it's moved between environments (uSync/Cloud) then the ContentBlock content although 'transferred' successfully doesn't get rendered by the ContentBlocksValueConverter because of the check to see if it is a string.

When Umbraco saves ContentBlocks within the BlockList JSON, then it escapes all the things \\\\\\ and when it's ready in the ConvertSourceToIntermediate it is interpreted as a string as it's no longer valid JArray...

but when it's moved by a serialisation/deserialisation tool, then actually the stored value is a valid JArray and Umbraco returns the object to ConvertSourceToIntermediate as a JArray...

... which is why this PropertyValueConverter skips displaying it ...

(but it loads the content fine in the backoffice)

this pragmatic suggestion sort of caters for this quite niche scenario - but also I don't think does any harm to non-niche scenarios and is the place in the whole setup with the least moving parts, but also also, spiritually I recognise this probably isn't the internationally agreed place to fix this sort of thing...

### Related Issues?

Here is a related conversation: https://github.com/Jumoo/uSync.Complete.Issues/issues/226

### Types of changes

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [x] Pragmatic Hack

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My code follows the coding style of this project.
- [ ] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [ ] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
