### PR TITLE
Data Picker: Data List source bridge

### DIFF
--- a/src/Umbraco.Cms.10.x/uSync/v10/ContentTypes/testmiscpage.config
+++ b/src/Umbraco.Cms.10.x/uSync/v10/ContentTypes/testmiscpage.config
@@ -40,6 +40,22 @@
       <LabelOnTop>false</LabelOnTop>
     </GenericProperty>
     <GenericProperty>
+      <Key>45248546-4d6c-4418-92e9-855c3aac8328</Key>
+      <Name>Data Picker - uCssClassName</Name>
+      <Alias>dataPickerUCssClassName</Alias>
+      <Definition>d4b190f2-e2a6-470c-a39f-8e1ae14d521c</Definition>
+      <Type>Umbraco.Community.Contentment.DataPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>20</SortOrder>
+      <Tab Alias="dataPicker">Data Picker</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
       <Key>a290a9de-0b71-49b7-9572-0bf541525469</Key>
       <Name>Data Picker - Umbraco Content</Name>
       <Alias>dataPickerUmbracoContent</Alias>

--- a/src/Umbraco.Cms.10.x/uSync/v10/DataTypes/ContentmentDataPickerWebUCssClassName.config
+++ b/src/Umbraco.Cms.10.x/uSync/v10/DataTypes/ContentmentDataPickerWebUCssClassName.config
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="d4b190f2-e2a6-470c-a39f-8e1ae14d521c" Alias="[Contentment] Data Picker - Web uCssClassName" Level="2">
+  <Info>
+    <Name>[Contentment] Data Picker - Web uCssClassName</Name>
+    <EditorAlias>Umbraco.Community.Contentment.DataPicker</EditorAlias>
+    <DatabaseType>Ntext</DatabaseType>
+    <Folder>Test+Data+Picker</Folder>
+  </Info>
+  <Config><![CDATA[{
+  "dataSource": [
+    {
+      "key": "Umbraco.Community.Contentment.DataEditors.uCssClassNameDataListSource, Umbraco.Community.Contentment",
+      "value": {
+        "cssPath": "~/umbraco/lib/font-awesome/css/font-awesome.min.css",
+        "cssRegex": "\\.fa-([^:]*?):before",
+        "excludeList": "",
+        "iconPattern": "icon-fa fa-{0}"
+      }
+    }
+  ],
+  "displayMode": [
+    {
+      "key": "Umbraco.Community.Contentment.DataEditors.CardsDataPickerDisplayMode, Umbraco.Community.Contentment",
+      "value": null
+    }
+  ],
+  "pageSize": 12,
+  "overlaySize": [
+    "medium"
+  ],
+  "hideSearch": "0",
+  "maxItems": 0,
+  "enableDevMode": "1"
+}]]></Config>
+</DataType>

--- a/src/Umbraco.Cms.13.x/uSync/v9/ContentTypes/testmiscpage.config
+++ b/src/Umbraco.Cms.13.x/uSync/v9/ContentTypes/testmiscpage.config
@@ -40,6 +40,22 @@
       <LabelOnTop>false</LabelOnTop>
     </GenericProperty>
     <GenericProperty>
+      <Key>2f56d9fd-2066-4905-9c2e-8e29c657fe10</Key>
+      <Name>Data Picker - uCssClassName</Name>
+      <Alias>dataPickerUCssClassName</Alias>
+      <Definition>882e9021-789a-412c-ac26-9818df51c647</Definition>
+      <Type>Umbraco.Community.Contentment.DataPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>20</SortOrder>
+      <Tab Alias="dataPicker">Data Picker</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
       <Key>a290a9de-0b71-49b7-9572-0bf541525469</Key>
       <Name>Data Picker - Umbraco Content</Name>
       <Alias>dataPickerUmbracoContent</Alias>

--- a/src/Umbraco.Cms.13.x/uSync/v9/DataTypes/ContentmentDataPickerWebUCssClassName.config
+++ b/src/Umbraco.Cms.13.x/uSync/v9/DataTypes/ContentmentDataPickerWebUCssClassName.config
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="882e9021-789a-412c-ac26-9818df51c647" Alias="[Contentment] Data Picker - Web uCssClassName" Level="2">
+  <Info>
+    <Name>[Contentment] Data Picker - Web uCssClassName</Name>
+    <EditorAlias>Umbraco.Community.Contentment.DataPicker</EditorAlias>
+    <DatabaseType>Ntext</DatabaseType>
+    <Folder>Test+Data+Picker</Folder>
+  </Info>
+  <Config><![CDATA[{
+  "dataSource": [
+    {
+      "key": "Umbraco.Community.Contentment.DataEditors.uCssClassNameDataListSource, Umbraco.Community.Contentment",
+      "value": {
+        "cssPath": "~/umbraco/lib/font-awesome/css/font-awesome.min.css",
+        "cssRegex": "\\.fa-([^:]*?):before",
+        "excludeList": "",
+        "iconPattern": "icon-fa fa-{0}"
+      }
+    }
+  ],
+  "displayMode": [
+    {
+      "key": "Umbraco.Community.Contentment.DataEditors.CardsDataPickerDisplayMode, Umbraco.Community.Contentment",
+      "value": {}
+    }
+  ],
+  "pageSize": 12,
+  "overlaySize": [
+    "medium"
+  ],
+  "hideSearch": "0",
+  "maxItems": 0,
+  "enableDevMode": "1"
+}]]></Config>
+</DataType>

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/DataListToDataPickerSourceBridge.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/DataListToDataPickerSourceBridge.cs
@@ -1,0 +1,76 @@
+/* Copyright © 2024 Lee Kelleher.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+#if NET472
+using Umbraco.Core;
+using Umbraco.Core.Models;
+using Umbraco.Core.PropertyEditors;
+#else
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Extensions;
+#endif
+
+namespace Umbraco.Community.Contentment.DataEditors
+{
+    public abstract class DataListToDataPickerSourceBridge : IDataListSource, IDataPickerSource
+    {
+        public abstract string Name { get; }
+
+        public abstract string Description { get; }
+
+        public abstract string Icon { get; }
+
+        public abstract string Group { get; }
+
+        public abstract IEnumerable<ConfigurationField> Fields { get; }
+
+        public abstract Dictionary<string, object> DefaultValues { get; }
+
+        public abstract OverlaySize OverlaySize { get; }
+
+        public abstract IEnumerable<DataListItem> GetItems(Dictionary<string, object> config);
+
+        public virtual Task<IEnumerable<DataListItem>> GetItemsAsync(Dictionary<string, object> config, IEnumerable<string> values)
+        {
+            var items = GetItems(config);
+
+            if (items?.Any() == true)
+            {
+                return Task.FromResult(items.Where(x => values.Contains(x.Value) == true));
+            }
+
+            return Task.FromResult(Enumerable.Empty<DataListItem>());
+        }
+
+        public virtual Task<PagedResult<DataListItem>> SearchAsync(Dictionary<string, object> config, int pageNumber = 1, int pageSize = 12, string query = "")
+        {
+            var items = default(IEnumerable<DataListItem>);
+
+            if (string.IsNullOrWhiteSpace(query) == true)
+            {
+                items = GetItems(config);
+            }
+            else
+            {
+                items = GetItems(config)?.Where(x => x.Name?.InvariantContains(query) == true || x.Value?.InvariantStartsWith(query) == true);
+            }
+
+            if (items?.Any() == true)
+            {
+                var offset = (pageNumber - 1) * pageSize;
+                return Task.FromResult(new PagedResult<DataListItem>(items.Count(), pageNumber, pageSize)
+                {
+                    Items = items.Skip(offset).Take(pageSize),
+                });
+            }
+
+            return Task.FromResult(new PagedResult<DataListItem>(-1, pageNumber, pageSize));
+        }
+    }
+}

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/EnumDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/EnumDataListSource.cs
@@ -28,7 +28,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class EnumDataListSource : IDataListSource, IDataSourceValueConverter, IContentmentListTemplateItem
+    public sealed class EnumDataListSource : DataListToDataPickerSourceBridge, IDataListSource, IDataSourceValueConverter, IContentmentListTemplateItem
     {
         private readonly ConcurrentDictionary<Type, (List<DataListItem>, Dictionary<string, object>)> _lookup;
         private readonly IIOHelper _ioHelper;
@@ -56,23 +56,23 @@ namespace Umbraco.Community.Contentment.DataEditors
             _ioHelper = ioHelper;
         }
 
-        public string Name => ".NET Enumeration";
+        public override string Name => ".NET Enumeration";
 
         public string NameTemplate => default;
 
-        public string Description => "Select an enumeration from a .NET assembly as the data source.";
+        public override string Description => "Select an enumeration from a .NET assembly as the data source.";
 
         public string DescriptionTemplate => "{{ enumType[1] }}";
 
-        public string Icon => "icon-indent";
+        public override string Icon => "icon-indent";
 
-        public string Group => Constants.Conventions.DataSourceGroups.DotNet;
+        public override string Group => Constants.Conventions.DataSourceGroups.DotNet;
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public Dictionary<string, object> DefaultValues => default;
+        public override Dictionary<string, object> DefaultValues => default;
 
-        public IEnumerable<ConfigurationField> Fields => new[]
+        public override IEnumerable<ConfigurationField> Fields => new[]
         {
             new ConfigurationField
             {
@@ -134,7 +134,7 @@ namespace Umbraco.Community.Contentment.DataEditors
             return (items, values);
         }
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             var type = GetValueType(config);
 

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/ExamineDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/ExamineDataListSource.cs
@@ -30,7 +30,7 @@ using UmbConstants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class ExamineDataListSource : IDataListSource
+    public sealed class ExamineDataListSource : DataListToDataPickerSourceBridge, IDataListSource
     {
 
         private readonly IContentmentContentContext _contentmentContentContext;
@@ -102,17 +102,17 @@ namespace Umbraco.Community.Contentment.DataEditors
             _shortStringHelper = shortStringHelper;
         }
 
-        public string Name => "Examine Query";
+        public override string Name => "Examine Query";
 
-        public string Description => "Populate the data source from an Examine query.";
+        public override string Description => "Populate the data source from an Examine query.";
 
-        public string Icon => "icon-search";
+        public override string Icon => "icon-search";
 
-        public string Group => Constants.Conventions.DataSourceGroups.Umbraco;
+        public override string Group => Constants.Conventions.DataSourceGroups.Umbraco;
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<ConfigurationField> Fields => new[]
+        public override IEnumerable<ConfigurationField> Fields => new[]
         {
             new ConfigurationField
             {
@@ -181,7 +181,7 @@ namespace Umbraco.Community.Contentment.DataEditors
             },
         };
 
-        public Dictionary<string, object> DefaultValues => new Dictionary<string, object>
+        public override Dictionary<string, object> DefaultValues => new Dictionary<string, object>()
         {
             { "examineIndex", UmbConstants.UmbracoIndexes.ExternalIndexName },
             { "luceneQuery", "+__IndexType:content" },
@@ -191,7 +191,7 @@ namespace Umbraco.Community.Contentment.DataEditors
             { "descriptionField", string.Empty },
         };
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             var examineIndex = config.GetValueAs("examineIndex", UmbConstants.UmbracoIndexes.ExternalIndexName);
             if (_examineManager.TryGetIndex(examineIndex, out var index) == true)

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/JsonDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/JsonDataListSource.cs
@@ -27,7 +27,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class JsonDataListSource : IDataListSource, IContentmentListTemplateItem
+    public sealed class JsonDataListSource : DataListToDataPickerSourceBridge, IDataListSource, IContentmentListTemplateItem
     {
         private readonly IWebHostEnvironment _webHostEnvironment;
         private readonly IIOHelper _ioHelper;
@@ -53,21 +53,21 @@ namespace Umbraco.Community.Contentment.DataEditors
             _ioHelper = ioHelper;
         }
 
-        public string Name => "JSON Data";
+        public override string Name => "JSON Data";
 
         public string NameTemplate => default;
 
-        public string Description => "Configure JSON data to populate the data source.";
+        public override string Description => "Configure JSON data to populate the data source.";
 
         public string DescriptionTemplate => "{{ url }}";
 
-        public string Icon => "icon-brackets";
+        public override string Icon => "icon-brackets";
 
-        public string Group => Constants.Conventions.DataSourceGroups.Data;
+        public override string Group => Constants.Conventions.DataSourceGroups.Data;
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<ConfigurationField> Fields => new[]
+        public override IEnumerable<ConfigurationField> Fields => new[]
         {
             new NotesConfigurationField(_ioHelper, $@"<details class=""well well-small"">
 <summary><strong>Do you need help with JSONPath expressions?</strong></summary>
@@ -120,7 +120,7 @@ namespace Umbraco.Community.Contentment.DataEditors
             },
         };
 
-        public Dictionary<string, object> DefaultValues => new Dictionary<string, object>
+        public override Dictionary<string, object> DefaultValues => new Dictionary<string, object>()
         {
             { "url", "https://leekelleher.com/umbraco/contentment/data.json" },
             { "itemsJsonPath", "$[*]" },
@@ -130,7 +130,7 @@ namespace Umbraco.Community.Contentment.DataEditors
             { "descriptionJsonPath", "$.description" },
         };
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             var url = config.GetValueAs("url", string.Empty);
 
@@ -226,6 +226,7 @@ namespace Umbraco.Community.Contentment.DataEditors
             catch (Exception ex)
             {
 #if NET472
+                // Error finding items in the JSON. Please check the syntax of your JSONPath expressions.
                 _logger.Error<JsonDataListSource>(ex, "Error finding items in the JSON. Please check the syntax of your JSONPath expressions.");
 #else
                 _logger.LogError(ex, "Error finding items in the JSON. Please check the syntax of your JSONPath expressions.");

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/NumberRangeDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/NumberRangeDataListSource.cs
@@ -19,7 +19,7 @@ using UmbConstants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class NumberRangeDataListSource : IDataListSource, IDataSourceValueConverter
+    public sealed class NumberRangeDataListSource : DataListToDataPickerSourceBridge, IDataListSource, IDataSourceValueConverter
     {
         private readonly IIOHelper _ioHelper;
 
@@ -28,15 +28,15 @@ namespace Umbraco.Community.Contentment.DataEditors
             _ioHelper = ioHelper;
         }
 
-        public string Name => "Number Range";
+        public override string Name => "Number Range";
 
-        public string Description => "Generates a sequence of numbers within a specified range.";
+        public override string Description => "Generates a sequence of numbers within a specified range.";
 
-        public string Icon => "icon-fa fa-sort-numeric-asc";
+        public override string Icon => "icon-fa fa-sort-numeric-asc";
 
-        public string Group => Constants.Conventions.DataSourceGroups.Data;
+        public override string Group => Constants.Conventions.DataSourceGroups.Data;
 
-        public IEnumerable<ConfigurationField> Fields => new[]
+        public override IEnumerable<ConfigurationField> Fields => new[]
         {
             new ConfigurationField
             {
@@ -90,7 +90,7 @@ namespace Umbraco.Community.Contentment.DataEditors
             }
         };
 
-        public Dictionary<string, object> DefaultValues => new Dictionary<string, object>
+        public override Dictionary<string, object> DefaultValues => new Dictionary<string, object>()
         {
             { "start", 1 },
             { "end", 10 },
@@ -98,9 +98,9 @@ namespace Umbraco.Community.Contentment.DataEditors
             { "decimals", 0 },
         };
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             var start = config.GetValueAs("start", defaultValue: default(double));
             var end = config.GetValueAs("end", defaultValue: default(double));

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/PhysicalFileSystemDataSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/PhysicalFileSystemDataSource.cs
@@ -26,7 +26,7 @@ using UmbConstants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class PhysicalFileSystemDataSource : IDataListSource, IContentmentListTemplateItem
+    public sealed class PhysicalFileSystemDataSource : DataListToDataPickerSourceBridge, IDataListSource, IContentmentListTemplateItem
     {
         private readonly IShortStringHelper _shortStringHelper;
 
@@ -57,21 +57,21 @@ namespace Umbraco.Community.Contentment.DataEditors
         }
 #endif
 
-        public string Name => "File System";
+        public override string Name => "File System";
 
         public string NameTemplate => default;
 
-        public string Description => "Select paths from the physical file system as the data source.";
+        public override string Description => "Select paths from the physical file system as the data source.";
 
         public string DescriptionTemplate => "{{ path }}; {{ filter }}";
 
-        public string Icon => "icon-folder-close";
+        public override string Icon => "icon-folder-close";
 
-        public string Group => Constants.Conventions.DataSourceGroups.Data;
+        public override string Group => Constants.Conventions.DataSourceGroups.Data;
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<ConfigurationField> Fields => new[]
+        public override IEnumerable<ConfigurationField> Fields => new[]
         {
             new ConfigurationField
             {
@@ -100,13 +100,13 @@ namespace Umbraco.Community.Contentment.DataEditors
             }
         };
 
-        public Dictionary<string, object> DefaultValues => new Dictionary<string, object>
+        public override Dictionary<string, object> DefaultValues => new Dictionary<string, object>()
         {
             { "path", "~/css" },
             { "filter", "*.css" },
         };
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             var path = config.GetValueAs("path", string.Empty);
             var filter = config.GetValueAs("filter", string.Empty);

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/SqlDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/SqlDataListSource.cs
@@ -8,11 +8,17 @@
  * please see the .NET472, .NET5_0 or .NET6_0 code files. */
 
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
 #if NET472
+using Umbraco.Core;
 using Umbraco.Core.IO;
+using Umbraco.Core.Models;
 using Umbraco.Core.PropertyEditors;
 using UmbConstants = Umbraco.Core.Constants;
 #else
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Extensions;
 using UmbConstants = Umbraco.Cms.Core.Constants;
@@ -20,7 +26,7 @@ using UmbConstants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed partial class SqlDataListSource : IDataListSource
+    public sealed partial class SqlDataListSource : IDataListSource, IDataPickerSource
     {
         public string Name => "SQL Data";
 
@@ -74,10 +80,47 @@ namespace Umbraco.Community.Contentment.DataEditors
             },
         };
 
-        public Dictionary<string, object> DefaultValues => new Dictionary<string, object>
+        public Dictionary<string, object> DefaultValues => new Dictionary<string, object>()
         {
             { "query", $"SELECT\r\n\t[text],\r\n\t[uniqueId]\r\nFROM\r\n\t[umbracoNode]\r\nWHERE\r\n\t[nodeObjectType] = '{UmbConstants.ObjectTypes.Strings.Document}'\r\n\tAND\r\n\t[level] = 1\r\nORDER BY\r\n\t[sortOrder] ASC\r\n\r\n-- This is an example query that will select all the content nodes that are at level 1.\r\n;" },
             { "connectionString", UmbConstants.System.UmbracoConnectionName }
         };
+
+        public Task<IEnumerable<DataListItem>> GetItemsAsync(Dictionary<string, object> config, IEnumerable<string> values)
+        {
+            var items = GetItems(config);
+
+            if (items?.Any() == true)
+            {
+                return Task.FromResult(items.Where(x => values.Contains(x.Value) == true));
+            }
+
+            return Task.FromResult(Enumerable.Empty<DataListItem>());
+        }
+
+        public Task<PagedResult<DataListItem>> SearchAsync(Dictionary<string, object> config, int pageNumber = 1, int pageSize = 12, string query = "")
+        {
+            var items = default(IEnumerable<DataListItem>);
+
+            if (string.IsNullOrWhiteSpace(query) == true)
+            {
+                items = GetItems(config);
+            }
+            else
+            {
+                items = GetItems(config)?.Where(x => x.Name?.InvariantContains(query) == true || x.Value?.InvariantStartsWith(query) == true);
+            }
+
+            if (items?.Any() == true)
+            {
+                var offset = (pageNumber - 1) * pageSize;
+                return Task.FromResult(new PagedResult<DataListItem>(items.Count(), pageNumber, pageSize)
+                {
+                    Items = items.Skip(offset).Take(pageSize),
+                });
+            }
+
+            return Task.FromResult(new PagedResult<DataListItem>(-1, pageNumber, pageSize));
+        }
     }
 }

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/TextDelimitedDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/TextDelimitedDataListSource.cs
@@ -24,7 +24,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class TextDelimitedDataListSource : IDataListSource, IContentmentListTemplateItem
+    public sealed class TextDelimitedDataListSource : DataListToDataPickerSourceBridge, IDataListSource, IContentmentListTemplateItem
     {
         private readonly IWebHostEnvironment _webHostEnvironment;
         private readonly IIOHelper _ioHelper;
@@ -55,21 +55,21 @@ namespace Umbraco.Community.Contentment.DataEditors
         }
 #endif
 
-        public string Name => "Text Delimited Data";
+        public override string Name => "Text Delimited Data";
 
         public string NameTemplate => default;
 
-        public string Description => "Configure text-delimited data to populate the data source.";
+        public override string Description => "Configure text-delimited data to populate the data source.";
 
         public string DescriptionTemplate => "{{ url }}";
 
-        public string Icon => "icon-fa fa-file-text-o";
+        public override string Icon => "icon-fa fa-file-text-o";
 
-        public string Group => Constants.Conventions.DataSourceGroups.Data;
+        public override string Group => Constants.Conventions.DataSourceGroups.Data;
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<ConfigurationField> Fields => new[]
+        public override IEnumerable<ConfigurationField> Fields => new[]
         {
             new NotesConfigurationField(_ioHelper, @"<details class=""well well-small"">
 <summary><strong>A note about using this data source.</strong></summary>
@@ -127,7 +127,7 @@ namespace Umbraco.Community.Contentment.DataEditors
             }
         };
 
-        public Dictionary<string, object> DefaultValues => new Dictionary<string, object>
+        public override Dictionary<string, object> DefaultValues => new Dictionary<string, object>()
         {
             { "url", "https://leekelleher.com/umbraco/contentment/data.csv" },
             { "delimiter", "," },
@@ -137,7 +137,7 @@ namespace Umbraco.Community.Contentment.DataEditors
             { "descriptionIndex", 3 },
         };
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             var items = new List<DataListItem>();
 

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/TimeZoneDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/TimeZoneDataListSource.cs
@@ -65,7 +65,7 @@ namespace Umbraco.Community.Contentment.DataEditors
             else
             {
                 items = GetItems(config)
-                    .Where(x => x.Name.InvariantContains(query) == true || x.Value.InvariantStartsWith(query) == true);
+                    .Where(x => x.Name?.InvariantContains(query) == true || x.Value?.InvariantStartsWith(query) == true);
             }
 
             if (items?.Any() == true)

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoBackofficeSectionsDataSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoBackofficeSectionsDataSource.cs
@@ -19,7 +19,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class UmbracoBackofficeSectionsDataSource : IDataListSource, IDataSourceValueConverter
+    public sealed class UmbracoBackofficeSectionsDataSource : DataListToDataPickerSourceBridge, IDataListSource, IDataSourceValueConverter
     {
         private readonly ISectionService _sectionService;
 
@@ -28,21 +28,21 @@ namespace Umbraco.Community.Contentment.DataEditors
             _sectionService = sectionService;
         }
 
-        public string Name => "Umbraco Backoffice Sections";
+        public override string Name => "Umbraco Backoffice Sections";
 
-        public string Description => "Use the backoffice sections to populate the data source.";
+        public override string Description => "Use the backoffice sections to populate the data source.";
 
-        public string Icon => "icon-section";
+        public override string Icon => "icon-section";
 
-        public string Group => Constants.Conventions.DataSourceGroups.Umbraco;
+        public override string Group => Constants.Conventions.DataSourceGroups.Umbraco;
 
-        public IEnumerable<ConfigurationField> Fields => default;
+        public override IEnumerable<ConfigurationField> Fields => Enumerable.Empty<ConfigurationField>();
 
-        public Dictionary<string, object> DefaultValues => default;
+        public override Dictionary<string, object> DefaultValues => default;
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             return _sectionService
                 .GetSections()

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentPropertiesDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentPropertiesDataListSource.cs
@@ -24,7 +24,7 @@ using UmbConstants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class UmbracoContentPropertiesDataListSource : IDataListSource
+    public sealed class UmbracoContentPropertiesDataListSource : DataListToDataPickerSourceBridge, IDataListSource
     {
         private readonly IContentTypeService _contentTypeService;
         private readonly Lazy<PropertyEditorCollection> _dataEditors;
@@ -41,15 +41,15 @@ namespace Umbraco.Community.Contentment.DataEditors
             _ioHelper = ioHelper;
         }
 
-        public string Name => "Umbraco Content Properties";
+        public override string Name => "Umbraco Content Properties";
 
-        public string Description => "Populate the data source using a Content Type's properties.";
+        public override string Description => "Populate the data source using a Content Type's properties.";
 
-        public string Icon => "icon-fa fa-tasks";
+        public override string Icon => "icon-fa fa-tasks";
 
-        public string Group => Constants.Conventions.DataSourceGroups.Umbraco;
+        public override string Group => Constants.Conventions.DataSourceGroups.Umbraco;
 
-        public IEnumerable<ConfigurationField> Fields
+        public override IEnumerable<ConfigurationField> Fields
         {
             get
             {
@@ -99,11 +99,11 @@ namespace Umbraco.Community.Contentment.DataEditors
             }
         }
 
-        public Dictionary<string, object> DefaultValues => default;
+        public override Dictionary<string, object> DefaultValues => default;
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             if (config.TryGetValueAs("contentType", out JArray array) == true &&
                 array.Count > 0 &&

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentPropertyValueDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentPropertyValueDataListSource.cs
@@ -34,7 +34,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.DataEditors.DataList.DataSources
 {
-    public sealed class UmbracoContentPropertyValueDataListSource : IDataListSource
+    public sealed class UmbracoContentPropertyValueDataListSource : DataListToDataPickerSourceBridge, IDataListSource
     {
         private readonly ContentmentDataListItemPropertyValueConverterCollection _converters;
         private readonly IContentmentContentContext _contentmentContentContext;
@@ -53,15 +53,15 @@ namespace Umbraco.Community.Contentment.DataEditors.DataList.DataSources
             _umbracoContextAccessor = umbracoContextAccessor;
         }
 
-        public string Name => "Umbraco Content Property Values";
+        public override string Name => "Umbraco Content Property Values";
 
-        public string Description => "Use Umbraco content property values to populate a data source.";
+        public override string Description => "Use Umbraco content property values to populate a data source.";
 
-        public string Icon => "icon-umbraco";
+        public override string Icon => "icon-umbraco";
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<ConfigurationField> Fields => new ConfigurationField[]
+        public override IEnumerable<ConfigurationField> Fields => new ConfigurationField[]
         {
             new ConfigurationField
             {
@@ -79,11 +79,11 @@ namespace Umbraco.Community.Contentment.DataEditors.DataList.DataSources
             },
         };
 
-        public Dictionary<string, object> DefaultValues => default;
+        public override Dictionary<string, object> DefaultValues => default;
 
-        public string Group => Constants.Conventions.DataSourceGroups.Umbraco;
+        public override string Group => Constants.Conventions.DataSourceGroups.Umbraco;
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             var contentNode = config.GetValueAs("contentNode", string.Empty);
             var propertyAlias = config.GetValueAs("propertyAlias", string.Empty);

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentTypesDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentTypesDataListSource.cs
@@ -31,7 +31,7 @@ using UmbConstants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class UmbracoContentTypesDataListSource : IDataListSource, IDataSourceValueConverter
+    public sealed class UmbracoContentTypesDataListSource : DataListToDataPickerSourceBridge, IDataListSource, IDataSourceValueConverter
     {
         private readonly IContentTypeService _contentTypeService;
         private readonly IUmbracoContextAccessor _umbracoContextAccessor;
@@ -59,17 +59,17 @@ namespace Umbraco.Community.Contentment.DataEditors
             _ioHelper = ioHelper;
         }
 
-        public string Name => "Umbraco Content Types";
+        public override string Name => "Umbraco Content Types";
 
-        public string Description => "Populate the data source using Content Types.";
+        public override string Description => "Populate the data source using Content Types.";
 
-        public string Icon => UmbConstants.Icons.ContentType;
+        public override string Icon => UmbConstants.Icons.ContentType;
 
-        public string Group => Constants.Conventions.DataSourceGroups.Umbraco;
+        public override string Group => Constants.Conventions.DataSourceGroups.Umbraco;
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<ConfigurationField> Fields => new[]
+        public override IEnumerable<ConfigurationField> Fields => new[]
         {
             new ConfigurationField
             {
@@ -111,9 +111,9 @@ namespace Umbraco.Community.Contentment.DataEditors
             },
         };
 
-        public Dictionary<string, object> DefaultValues => default;
+        public override Dictionary<string, object> DefaultValues => default;
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             var types = config.GetValueAs("contentTypes", defaultValue: default(JArray))?.ToObject<IEnumerable<string>>();
 

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentXPathDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentXPathDataListSource.cs
@@ -26,7 +26,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class UmbracoContentXPathDataListSource : IDataListSource, IDataSourceValueConverter
+    public sealed class UmbracoContentXPathDataListSource : DataListToDataPickerSourceBridge, IDataListSource, IDataSourceValueConverter
     {
         private readonly IContentmentContentContext _contentmentContentContext;
         private readonly IUmbracoContextAccessor _umbracoContextAccessor;
@@ -42,15 +42,15 @@ namespace Umbraco.Community.Contentment.DataEditors
             _ioHelper = ioHelper;
         }
 
-        public string Name => "Umbraco Content by XPath";
+        public override string Name => "Umbraco Content by XPath";
 
-        public string Description => "Use an XPath query to select Umbraco content to use as the data source.";
+        public override string Description => "Use an XPath query to select Umbraco content to use as the data source.";
 
-        public string Icon => "icon-fa fa-file-code-o";
+        public override string Icon => "icon-fa fa-file-code-o";
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<ConfigurationField> Fields => new ConfigurationField[]
+        public override IEnumerable<ConfigurationField> Fields => new ConfigurationField[]
         {
             new ConfigurationField
             {
@@ -79,14 +79,14 @@ namespace Umbraco.Community.Contentment.DataEditors
 </details>", true),
         };
 
-        public Dictionary<string, object> DefaultValues => new Dictionary<string, object>
+        public override Dictionary<string, object> DefaultValues => new Dictionary<string, object>()
         {
             { "xpath", "/root/*[@level = 1]/*[@isDoc]" },
         };
 
-        public string Group => Constants.Conventions.DataSourceGroups.Umbraco;
+        public override string Group => Constants.Conventions.DataSourceGroups.Umbraco;
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             var xpath = config.GetValueAs("xpath", string.Empty);
 

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoDictionaryDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoDictionaryDataListSource.cs
@@ -24,7 +24,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class UmbracoDictionaryDataListSource : IDataListSource
+    public sealed class UmbracoDictionaryDataListSource : DataListToDataPickerSourceBridge, IDataListSource
     {
         private readonly ILocalizationService _localizationService;
         private readonly IIOHelper _ioHelper;
@@ -37,15 +37,15 @@ namespace Umbraco.Community.Contentment.DataEditors
             _ioHelper = ioHelper;
         }
 
-        public string Name => "Umbraco Dictionary Items";
+        public override string Name => "Umbraco Dictionary Items";
 
-        public string Description => "Select an Umbraco dictionary item to populate the data source with its child items.";
+        public override string Description => "Select an Umbraco dictionary item to populate the data source with its child items.";
 
-        public string Icon => "icon-book-alt";
+        public override string Icon => "icon-book-alt";
 
-        public string Group => Constants.Conventions.DataSourceGroups.Umbraco;
+        public override string Group => Constants.Conventions.DataSourceGroups.Umbraco;
 
-        public IEnumerable<ConfigurationField> Fields => new[]
+        public override IEnumerable<ConfigurationField> Fields => new[]
         {
             new ConfigurationField
             {
@@ -60,11 +60,11 @@ namespace Umbraco.Community.Contentment.DataEditors
             }
         };
 
-        public Dictionary<string, object> DefaultValues => default;
+        public override Dictionary<string, object> DefaultValues => default;
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             if (config.TryGetValueAs("item", out JArray array) == true &&
                 array.Count > 0 &&

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoEntityDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoEntityDataListSource.cs
@@ -29,7 +29,7 @@ using UmbConstants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class UmbracoEntityDataListSource : IDataListSource, IDataSourceValueConverter
+    public sealed class UmbracoEntityDataListSource : DataListToDataPickerSourceBridge, IDataListSource, IDataSourceValueConverter
     {
         internal static Dictionary<string, UmbracoObjectTypes> SupportedEntityTypes = new Dictionary<string, UmbracoObjectTypes>
         {
@@ -69,15 +69,15 @@ namespace Umbraco.Community.Contentment.DataEditors
             _ioHelper = ioHelper;
         }
 
-        public string Name => "Umbraco Entities";
+        public override string Name => "Umbraco Entities";
 
-        public string Description => "Select an Umbraco entity type to populate the data source.";
+        public override string Description => "Select an Umbraco entity type to populate the data source.";
 
-        public string Icon => "icon-lab";
+        public override string Icon => "icon-lab";
 
-        public string Group => Constants.Conventions.DataSourceGroups.Umbraco;
+        public override string Group => Constants.Conventions.DataSourceGroups.Umbraco;
 
-        public IEnumerable<ConfigurationField> Fields => new ConfigurationField[]
+        public override IEnumerable<ConfigurationField> Fields => new ConfigurationField[]
         {
             new NotesConfigurationField(_ioHelper, @"<details class=""well well-small"">
 <summary><strong>A note about supported Umbraco entity types.</strong></summary>
@@ -103,11 +103,11 @@ namespace Umbraco.Community.Contentment.DataEditors
             }
         };
 
-        public Dictionary<string, object> DefaultValues => default;
+        public override Dictionary<string, object> DefaultValues => default;
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             if (config.TryGetValueAs("entityType", out string entityType) == true && SupportedEntityTypes.TryGetValue(entityType, out var objectType) == true)
             {

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoFilesDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoFilesDataListSource.cs
@@ -23,7 +23,7 @@ using UmbConstants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class UmbracoFilesDataListSource : IDataListSource
+    public sealed class UmbracoFilesDataListSource : DataListToDataPickerSourceBridge, IDataListSource
     {
         private static readonly Dictionary<string, string> _icons = new Dictionary<string, string>
         {
@@ -45,17 +45,17 @@ namespace Umbraco.Community.Contentment.DataEditors
             _textService = textService;
         }
 
-        public string Name => "Umbraco Files";
+        public override string Name => "Umbraco Files";
 
-        public string Description => "Use files defined in Umbraco, such as scripts or stylesheets.";
+        public override string Description => "Use files defined in Umbraco, such as scripts or stylesheets.";
 
-        public string Icon => "icon-notepad-alt";
+        public override string Icon => "icon-notepad-alt";
 
-        public string Group => Constants.Conventions.DataSourceGroups.Umbraco;
+        public override string Group => Constants.Conventions.DataSourceGroups.Umbraco;
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<ConfigurationField> Fields => new[]
+        public override IEnumerable<ConfigurationField> Fields => new[]
         {
             new ConfigurationField
             {
@@ -110,13 +110,13 @@ namespace Umbraco.Community.Contentment.DataEditors
             },
         };
 
-        public Dictionary<string, object> DefaultValues => new Dictionary<string, object>
+        public override Dictionary<string, object> DefaultValues => new Dictionary<string, object>()
         {
             { "fileType", UmbConstants.UdiEntityType.Stylesheet },
             { "valueType", "alias" },
         };
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             var fileType = config.GetValueAs("fileType", defaultValue: UmbConstants.UdiEntityType.Stylesheet);
             var valueType = config.GetValueAs("valueType", defaultValue: "alias");

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoImageCropDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoImageCropDataListSource.cs
@@ -24,7 +24,7 @@ using UmbConstants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class UmbracoImageCropDataListSource : IDataListSource
+    public sealed class UmbracoImageCropDataListSource : DataListToDataPickerSourceBridge, IDataListSource
     {
         private readonly IDataTypeService _dataTypeService;
         private readonly IIOHelper _ioHelper;
@@ -37,15 +37,15 @@ namespace Umbraco.Community.Contentment.DataEditors
             _ioHelper = ioHelper;
         }
 
-        public string Name => "Umbraco Image Crops";
+        public override string Name => "Umbraco Image Crops";
 
-        public string Description => "Select an Image Cropper data-type to use its defined crops to populate the data source.";
+        public override string Description => "Select an Image Cropper data-type to use its defined crops to populate the data source.";
 
-        public string Icon => "icon-crop";
+        public override string Icon => "icon-crop";
 
-        public string Group => Constants.Conventions.DataSourceGroups.Umbraco;
+        public override string Group => Constants.Conventions.DataSourceGroups.Umbraco;
 
-        public IEnumerable<ConfigurationField> Fields
+        public override IEnumerable<ConfigurationField> Fields
         {
             get
             {
@@ -77,11 +77,11 @@ namespace Umbraco.Community.Contentment.DataEditors
             }
         }
 
-        public Dictionary<string, object> DefaultValues => default;
+        public override Dictionary<string, object> DefaultValues => default;
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             if (config.TryGetValue("imageCropper", out var obj) == true &&
                 obj is string str &&

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoLanguagesDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoLanguagesDataListSource.cs
@@ -17,7 +17,7 @@ using UmbConstants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class UmbracoLanguagesDataListSource : IDataListSource
+    public sealed class UmbracoLanguagesDataListSource : DataListToDataPickerSourceBridge, IDataListSource
     {
         private readonly ILocalizationService _localizationService;
 
@@ -26,21 +26,21 @@ namespace Umbraco.Community.Contentment.DataEditors
             _localizationService = localizationService;
         }
 
-        public string Name => "Umbraco Languages";
+        public override string Name => "Umbraco Languages";
 
-        public string Description => "Populate the data source with languages configured in Umbraco.";
+        public override string Description => "Populate the data source with languages configured in Umbraco.";
 
-        public string Icon => UmbConstants.Icons.Language;
+        public override string Icon => UmbConstants.Icons.Language;
 
-        public string Group => Constants.Conventions.DataSourceGroups.Umbraco;
+        public override string Group => Constants.Conventions.DataSourceGroups.Umbraco;
 
-        public IEnumerable<ConfigurationField> Fields => default;
+        public override IEnumerable<ConfigurationField> Fields => Enumerable.Empty<ConfigurationField>();
 
-        public Dictionary<string, object> DefaultValues => default;
+        public override Dictionary<string, object> DefaultValues => default;
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             return _localizationService
                 .GetAllLanguages()

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoMemberGroupDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoMemberGroupDataListSource.cs
@@ -20,7 +20,7 @@ using UmbConstants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class UmbracoMemberGroupDataListSource : IDataListSource, IDataSourceValueConverter
+    public sealed class UmbracoMemberGroupDataListSource : DataListToDataPickerSourceBridge, IDataListSource, IDataSourceValueConverter
     {
         private readonly IMemberGroupService _memberGroupService;
 
@@ -29,21 +29,21 @@ namespace Umbraco.Community.Contentment.DataEditors
             _memberGroupService = memberGroupService;
         }
 
-        public string Name => "Umbraco Member Groups";
+        public override string Name => "Umbraco Member Groups";
 
-        public string Description => "Populate the data source with Umbraco member groups.";
+        public override string Description => "Populate the data source with Umbraco member groups.";
 
-        public string Icon => UmbConstants.Icons.MemberGroup;
+        public override string Icon => UmbConstants.Icons.MemberGroup;
 
-        public string Group => Constants.Conventions.DataSourceGroups.Umbraco;
+        public override string Group => Constants.Conventions.DataSourceGroups.Umbraco;
 
-        public IEnumerable<ConfigurationField> Fields => default;
+        public override IEnumerable<ConfigurationField> Fields => Enumerable.Empty<ConfigurationField>();
 
-        public Dictionary<string, object> DefaultValues => default;
+        public override Dictionary<string, object> DefaultValues => default;
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             return _memberGroupService
                 .GetAll()

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoTagsDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoTagsDataListSource.cs
@@ -20,7 +20,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class UmbracoTagsDataListSource : IDataListSource
+    public sealed class UmbracoTagsDataListSource : DataListToDataPickerSourceBridge, IDataListSource
     {
 #if NET472
         private readonly Lazy<ITagQuery> _tagQuery;
@@ -38,17 +38,17 @@ namespace Umbraco.Community.Contentment.DataEditors
         }
 #endif
 
-        public string Name => "Umbraco Tags";
+        public override string Name => "Umbraco Tags";
 
-        public string Description => "Populate the data source using already defined tags.";
+        public override string Description => "Populate the data source using already defined tags.";
 
-        public string Icon => "icon-tags";
+        public override string Icon => "icon-tags";
 
-        public string Group => Constants.Conventions.DataSourceGroups.Umbraco;
+        public override string Group => Constants.Conventions.DataSourceGroups.Umbraco;
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<ConfigurationField> Fields => new[]
+        public override IEnumerable<ConfigurationField> Fields => new[]
         {
             new ConfigurationField
             {
@@ -59,12 +59,12 @@ namespace Umbraco.Community.Contentment.DataEditors
             },
         };
 
-        public Dictionary<string, object> DefaultValues => new Dictionary<string, object>
+        public override Dictionary<string, object> DefaultValues => new Dictionary<string, object>()
         {
             { "tagGroup", "default" },
         };
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             var tagGroup = config.GetValueAs("tagGroup", defaultValue: string.Empty);
 

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoTemplatesDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoTemplatesDataListSource.cs
@@ -25,7 +25,7 @@ using UmbConstants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class UmbracoTemplatesDataListSource : IDataListSource, IDataSourceValueConverter
+    public sealed class UmbracoTemplatesDataListSource : DataListToDataPickerSourceBridge, IDataListSource, IDataSourceValueConverter
     {
         private readonly IFileService _fileService;
         private readonly IIOHelper _ioHelper;
@@ -38,17 +38,17 @@ namespace Umbraco.Community.Contentment.DataEditors
             _ioHelper = ioHelper;
         }
 
-        public string Name => "Umbraco Templates";
+        public override string Name => "Umbraco Templates";
 
-        public string Description => "Populate the data source using defined view templates.";
+        public override string Description => "Populate the data source using defined view templates.";
 
-        public string Icon => UmbConstants.Icons.Template;
+        public override string Icon => UmbConstants.Icons.Template;
 
-        public string Group => Constants.Conventions.DataSourceGroups.Umbraco;
+        public override string Group => Constants.Conventions.DataSourceGroups.Umbraco;
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<ConfigurationField> Fields => new[]
+        public override IEnumerable<ConfigurationField> Fields => new[]
         {
             new ConfigurationField
             {
@@ -85,12 +85,12 @@ namespace Umbraco.Community.Contentment.DataEditors
             },
         };
 
-        public Dictionary<string, object> DefaultValues => new Dictionary<string, object>
+        public override Dictionary<string, object> DefaultValues => new Dictionary<string, object>()
         {
             { "valueType", "udi" },
         };
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             var valueType = config.GetValueAs("valueType", defaultValue: "udi");
 

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoUserGroupDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoUserGroupDataListSource.cs
@@ -20,7 +20,7 @@ using UmbConstants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class UmbracoUserGroupDataListSource : IDataListSource, IDataSourceValueConverter
+    public sealed class UmbracoUserGroupDataListSource : DataListToDataPickerSourceBridge, IDataListSource, IDataSourceValueConverter
     {
         private readonly IUserService _userService;
 
@@ -29,21 +29,21 @@ namespace Umbraco.Community.Contentment.DataEditors
             _userService = userService;
         }
 
-        public string Name => "Umbraco User Groups";
+        public override string Name => "Umbraco User Groups";
 
-        public string Description => "Populate the data source with Umbraco user groups.";
+        public override string Description => "Populate the data source with Umbraco user groups.";
 
-        public string Icon => UmbConstants.Icons.UserGroup;
+        public override string Icon => UmbConstants.Icons.UserGroup;
 
-        public string Group => Constants.Conventions.DataSourceGroups.Umbraco;
+        public override string Group => Constants.Conventions.DataSourceGroups.Umbraco;
 
-        public IEnumerable<ConfigurationField> Fields => default;
+        public override IEnumerable<ConfigurationField> Fields => Enumerable.Empty<ConfigurationField>();
 
-        public Dictionary<string, object> DefaultValues => default;
+        public override Dictionary<string, object> DefaultValues => default;
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             return _userService
                 .GetAllUserGroups()

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoUsersDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoUsersDataListSource.cs
@@ -25,7 +25,7 @@ using UmbConstants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class UmbracoUsersDataListSource : IDataListSource, IDataSourceValueConverter
+    public sealed class UmbracoUsersDataListSource : DataListToDataPickerSourceBridge, IDataListSource, IDataSourceValueConverter
     {
         private readonly IIOHelper _ioHelper;
         private readonly IUserService _userService;
@@ -36,15 +36,15 @@ namespace Umbraco.Community.Contentment.DataEditors
             _userService = userService;
         }
 
-        public string Name => "Umbraco Users";
+        public override string Name => "Umbraco Users";
 
-        public string Description => "Use Umbraco users to populate the data source.";
+        public override string Description => "Use Umbraco users to populate the data source.";
 
-        public string Icon => UmbConstants.Icons.User;
+        public override string Icon => UmbConstants.Icons.User;
 
-        public string Group => Constants.Conventions.DataSourceGroups.Umbraco;
+        public override string Group => Constants.Conventions.DataSourceGroups.Umbraco;
 
-        public IEnumerable<ConfigurationField> Fields
+        public override IEnumerable<ConfigurationField> Fields
         {
             get
             {
@@ -80,11 +80,11 @@ namespace Umbraco.Community.Contentment.DataEditors
             }
         }
 
-        public Dictionary<string, object> DefaultValues => default;
+        public override Dictionary<string, object> DefaultValues => default;
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             DataListItem mapUser(IUser user)
             {

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UserDefinedDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UserDefinedDataListSource.cs
@@ -20,7 +20,7 @@ using UmbConstants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class UserDefinedDataListSource : IDataListSource, IContentmentListTemplateItem
+    public sealed class UserDefinedDataListSource : DataListToDataPickerSourceBridge, IDataListSource, IContentmentListTemplateItem
     {
         private readonly IIOHelper _ioHelper;
 
@@ -29,19 +29,19 @@ namespace Umbraco.Community.Contentment.DataEditors
             _ioHelper = ioHelper;
         }
 
-        public string Name => "User-defined List";
+        public override string Name => "User-defined List";
 
         public string NameTemplate => default;
 
-        public string Description => "Manually configure the items for the data source.";
+        public override string Description => "Manually configure the items for the data source.";
 
         public string DescriptionTemplate => "{{ items.length }} {{ items.length === 1 ? 'item' : 'items' }} defined.";
 
-        public string Icon => UmbConstants.Icons.DataType;
+        public override string Icon => UmbConstants.Icons.DataType;
 
-        public string Group => Constants.Conventions.DataSourceGroups.Data;
+        public override string Group => Constants.Conventions.DataSourceGroups.Data;
 
-        public IEnumerable<ConfigurationField> Fields => new[]
+        public override IEnumerable<ConfigurationField> Fields => new[]
         {
             new ConfigurationField
             {
@@ -81,11 +81,11 @@ namespace Umbraco.Community.Contentment.DataEditors
             }
         };
 
-        public Dictionary<string, object> DefaultValues => default;
+        public override Dictionary<string, object> DefaultValues => default;
 
-        public OverlaySize OverlaySize => OverlaySize.Medium;
+        public override OverlaySize OverlaySize => OverlaySize.Medium;
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             return config.TryGetValueAs("items", out JArray array) == true
                 ? array.ToObject<IEnumerable<DataListItem>>().DistinctBy(x => x.Value)

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/XmlDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/XmlDataListSource.cs
@@ -27,7 +27,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class XmlDataListSource : IDataListSource, IContentmentListTemplateItem
+    public sealed class XmlDataListSource : DataListToDataPickerSourceBridge, IDataListSource, IContentmentListTemplateItem
     {
         private readonly IWebHostEnvironment _webHostEnvironment;
         private readonly IIOHelper _ioHelper;
@@ -58,21 +58,21 @@ namespace Umbraco.Community.Contentment.DataEditors
         }
 #endif
 
-        public string Name => "XML Data";
+        public override string Name => "XML Data";
 
         public string NameTemplate => default;
 
-        public string Description => "Configure XML data to populate the data source.";
+        public override string Description => "Configure XML data to populate the data source.";
 
         public string DescriptionTemplate => "{{ url }}";
 
-        public string Icon => "icon-code";
+        public override string Icon => "icon-code";
 
-        public string Group => Constants.Conventions.DataSourceGroups.Data;
+        public override string Group => Constants.Conventions.DataSourceGroups.Data;
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<ConfigurationField> Fields => new ConfigurationField[]
+        public override IEnumerable<ConfigurationField> Fields => new ConfigurationField[]
         {
             new ConfigurationField
             {
@@ -126,7 +126,7 @@ namespace Umbraco.Community.Contentment.DataEditors
             },
         };
 
-        public Dictionary<string, object> DefaultValues => new Dictionary<string, object>
+        public override Dictionary<string, object> DefaultValues => new Dictionary<string, object>()
         {
             { "url", "https://leekelleher.com/umbraco/contentment/data.xml" },
             { "itemsXPath", "/items/item" },
@@ -136,7 +136,7 @@ namespace Umbraco.Community.Contentment.DataEditors
             { "descriptionXPath", "@description" },
         };
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             var url = config.GetValueAs("url", string.Empty);
 

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/XmlSitemapChangeFrequencyDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/XmlSitemapChangeFrequencyDataListSource.cs
@@ -15,7 +15,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class XmlSitemapChangeFrequencyDataListSource : IDataListSource
+    public sealed class XmlSitemapChangeFrequencyDataListSource : DataListToDataPickerSourceBridge, IDataListSource
     {
         private readonly string[] _options;
 
@@ -33,21 +33,21 @@ namespace Umbraco.Community.Contentment.DataEditors
             };
         }
 
-        public string Name => "XML Sitemap: Change Frequency";
+        public override string Name => "XML Sitemap: Change Frequency";
 
-        public string Description => "Populate the data source using XML Sitemap change frequency values.";
+        public override string Description => "Populate the data source using XML Sitemap change frequency values.";
 
-        public string Icon => "icon-fa fa-signal";
+        public override string Icon => "icon-fa fa-signal";
 
-        public string Group => Constants.Conventions.DataSourceGroups.Web;
+        public override string Group => Constants.Conventions.DataSourceGroups.Web;
 
-        public IEnumerable<ConfigurationField> Fields => default;
+        public override IEnumerable<ConfigurationField> Fields => Enumerable.Empty<ConfigurationField>();
 
-        public Dictionary<string, object> DefaultValues => default;
+        public override Dictionary<string, object> DefaultValues => default;
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             return _options.Select(x => new DataListItem { Name = x.ToFirstUpperInvariant(), Value = x });
         }

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/XmlSitemapPriorityDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/XmlSitemapPriorityDataListSource.cs
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 using System.Collections.Generic;
+using System.Linq;
 #if NET472
 using Umbraco.Core.PropertyEditors;
 #else
@@ -12,23 +13,23 @@ using Umbraco.Cms.Core.PropertyEditors;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class XmlSitemapPriorityDataListSource : IDataListSource
+    public sealed class XmlSitemapPriorityDataListSource : DataListToDataPickerSourceBridge, IDataListSource
     {
-        public string Name => "XML Sitemap: Priority";
+        public override string Name => "XML Sitemap: Priority";
 
-        public string Description => "Populate the data source using XML Sitemap priority values.";
+        public override string Description => "Populate the data source using XML Sitemap priority values.";
 
-        public string Icon => "icon-fa fa-exclamation-circle";
+        public override string Icon => "icon-fa fa-exclamation-circle";
 
-        public string Group => Constants.Conventions.DataSourceGroups.Web;
+        public override string Group => Constants.Conventions.DataSourceGroups.Web;
 
-        public IEnumerable<ConfigurationField> Fields => default;
+        public override IEnumerable<ConfigurationField> Fields => Enumerable.Empty<ConfigurationField>();
 
-        public Dictionary<string, object> DefaultValues => default;
+        public override Dictionary<string, object> DefaultValues => default;
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             for (var i = 0.0D; i <= 1.0D; i += 0.1D)
             {

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/uCssClassNameDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/uCssClassNameDataListSource.cs
@@ -23,7 +23,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public class uCssClassNameDataListSource : IDataListSource
+    public class uCssClassNameDataListSource : DataListToDataPickerSourceBridge, IDataListSource
     {
         private readonly IWebHostEnvironment _webHostEnvironment;
         private readonly IIOHelper _ioHelper;
@@ -36,15 +36,15 @@ namespace Umbraco.Community.Contentment.DataEditors
             _ioHelper = ioHelper;
         }
 
-        public string Name => "uCssClassName";
+        public override string Name => "uCssClassName";
 
-        public string Description => "A homage to @marcemarc's bingo-famous uCssClassNameDropdown package!";
+        public override string Description => "A homage to @marcemarc's bingo-famous uCssClassNameDropdown package!";
 
-        public string Icon => "icon-fa fa-css3";
+        public override string Icon => "icon-fa fa-css3";
 
-        public string Group => Constants.Conventions.DataSourceGroups.Web;
+        public override string Group => Constants.Conventions.DataSourceGroups.Web;
 
-        public IEnumerable<ConfigurationField> Fields => new[]
+        public override IEnumerable<ConfigurationField> Fields => new[]
         {
             new NotesConfigurationField(_ioHelper, @"<details class=""well well-small"">
 <summary><strong>uCssClassName? <em>What sort of a name is that?</em></strong></summary>
@@ -88,7 +88,7 @@ namespace Umbraco.Community.Contentment.DataEditors
             },
         };
 
-        public Dictionary<string, object> DefaultValues => new Dictionary<string, object>
+        public override Dictionary<string, object> DefaultValues => new Dictionary<string, object>()
         {
             { "cssPath", "~/umbraco/lib/font-awesome/css/font-awesome.min.css" },
             { "cssRegex", "\\.fa-([^:]*?):before" },
@@ -96,9 +96,9 @@ namespace Umbraco.Community.Contentment.DataEditors
             { "iconPattern", "icon-fa fa-{0}" },
         };
 
-        public OverlaySize OverlaySize => OverlaySize.Small;
+        public override OverlaySize OverlaySize => OverlaySize.Small;
 
-        public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
+        public override IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
             var cssPath = config.GetValueAs("cssPath", string.Empty);
             var cssRegex = config.GetValueAs("cssRegex", string.Empty);

--- a/src/Umbraco.Community.Contentment/DataEditors/DataPicker/DataPickerConfigurationEditor.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataPicker/DataPickerConfigurationEditor.cs
@@ -73,6 +73,11 @@ namespace Umbraco.Community.Contentment.DataEditors
                     { Constants.Conventions.ConfigurationFieldAliases.AddButtonLabelKey, "contentment_configureDataSource" },
                     { Constants.Conventions.ConfigurationFieldAliases.Items, dataSources },
                     { EnableFilterConfigurationField.EnableFilter, dataSources.Count > 10 ? Constants.Values.True : Constants.Values.False },
+                    { "help", new {
+                        @class = "alert alert-info",
+                        title = "Do you need a custom data-source?",
+                        notes = $@"<p>If one of the data-sources above does not fit your needs, you can extend Data Picker with your own custom data source.</p>
+<p>To do this, read the documentation on <a href=""{Constants.Package.RepositoryUrl}/blob/develop/docs/editors/data-picker.md#extending-with-your-own-custom-data-source"" target=""_blank"" rel=""noopener""><strong>extending with your own custom data source</strong></a>.</p>" } },
                 }
             });
 


### PR DESCRIPTION
### Description

Added bridging code for Data Picker to support any Data List data-source.

Added the `DataListToDataPickerSourceBridge` abstract class to all the existing Data List data-sources.

> [!TIP]
> For developers who would like to use this feature in their own custom data-sources, they can inherit from the `DataListToDataPickerSourceBridge` abstract class and `override` the various properties (e.g. `Name`, `Icon`, etc).


### Types of changes

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [x] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
