### PR TITLE
Added `versionAssemblyName` to `package.manifest` file

### DIFF
--- a/src/Umbraco.Community.Contentment/Web/UI/App_Plugins/Contentment/package.manifest
+++ b/src/Umbraco.Community.Contentment/Web/UI/App_Plugins/Contentment/package.manifest
@@ -1,6 +1,7 @@
 ﻿{
     "name": "Contentment",
     "id": "Umbraco.Community.Contentment",
+    "versionAssemblyName": "Umbraco.Community.Contentment",
     "version": "4.6.1",
     "css": [ "~/App_Plugins/Contentment/contentment.css" ],
     "javascript": [ "~/App_Plugins/Contentment/contentment.js" ]


### PR DESCRIPTION
Hi @leekelleher 

Similar to #348 where I added the `id` property to Contentment's `package.manifest` file, there is also a `versionAssemblyName`  property, which - among other things - Umbraco uses for their own package telemetry. Here is the description from the [JSON schema store](https://json.schemastore.org/package.manifest):

> The assembly name to retrieve the informational version, if no explicit `version` is set. If not specified, uses the `id` instead (supported in v12+).

This PR adds the property with the value `Umbraco.Community.Contentment`, matching the name of the Contentment assembly.

I've been playing around with adding an improved package list to my [Iddqd](https://github.com/abjerner/Limbo.Umbraco.Iddqd) package, which will also use the `versionAssemblyName` for detecting the underlying assembly, and grabbing some additional information from the assembly.

With this property in Contentment's `package.manifest` file, my package can show the information in the **Assembly** box as well as the **GitHub** button as this information is pulled from the assembly.

![image](https://github.com/leekelleher/umbraco-contentment/assets/3634580/b75c56a4-6c60-417e-9faf-dc25984dedbc)

The `versionAssemblyName` was introduced in Umbraco 12, so it will be used by Umbraco 12 and 13. My package will however also be able to detect it for Umbraco 10 and 11.

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
     Please do not upgrade any NuGet dependencies.
     Please do not modify any licensing information, e.g. do not update the copyright year. -->

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [x] Other

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
