### PR TITLE
[V6] Set Status Dashboard to Settings only

### DIFF
--- a/src/Umbraco.Community.Contentment/Client/src/dashboard/bellissima-status/manifest.ts
+++ b/src/Umbraco.Community.Contentment/Client/src/dashboard/bellissima-status/manifest.ts
@@ -13,7 +13,7 @@ export const manifest: ManifestDashboard = {
 	conditions: [
 		{
 			alias: 'Umb.Condition.SectionAlias',
-			oneOf: ['Umb.Section.Content', 'Umb.Section.Settings'],
+			match: 'Umb.Section.Settings',
 		},
 	],
 };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

### Description

<!-- Please include a summary of the change and which issue is fixed.
     Please also include relevant motivation and context.
     List any dependencies that are required for this change. -->

Just a simple change to make the status dashboard from Content & Settings to just to be the Settings section.
Why, well whilst during active development of an Umbraco V14 site its kind of noisy to be on the content section but super useful to still have in the Settings section.

### Related Issues?

<!-- If suggesting a new feature or change, please discuss it in an issue first.
     If fixing a bug for an existing issue, please link to the issue here: -->

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
     Please do not upgrade any NuGet dependencies.
     Please do not modify any licensing information, e.g. do not update the copyright year. -->

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [x] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
