### PR TITLE
Data List: Adds "contentment.update.value" event to List Editors

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/Buttons/buttons.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/Buttons/buttons.js
@@ -1,11 +1,12 @@
-﻿/* Copyright © 2020 Lee Kelleher.
+/* Copyright © 2020 Lee Kelleher.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.Buttons.Controller", [
     "$scope",
-    function ($scope) {
+    "eventsService",
+    function ($scope, eventsService) {
 
         // console.log("buttons.model", $scope.model);
 
@@ -79,6 +80,21 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
                     $scope.umbProperty.setPropertyActions(vm.propertyActions);
                 }
             }
+
+            var events = [];
+
+            events.push(eventsService.on("contentment.update.value", (event, args) => {
+                if (args.alias === $scope.model.alias) {
+                    $scope.model.value = args.value;
+                    init();
+                }
+            }));
+
+            $scope.$on("$destroy", () => {
+                for (var event in events) {
+                    eventsService.unsubscribe(events[event]);
+                }
+            });
         };
 
         function clear() {

--- a/src/Umbraco.Community.Contentment/DataEditors/CheckboxList/checkbox-list.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/CheckboxList/checkbox-list.js
@@ -1,12 +1,13 @@
-﻿/* Copyright © 2019 Lee Kelleher.
+/* Copyright © 2019 Lee Kelleher.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.CheckboxList.Controller", [
     "$scope",
+    "eventsService",
     "localizationService",
-    function ($scope, localizationService) {
+    function ($scope, eventsService, localizationService) {
 
         // console.log("checkboxlist.model", $scope.model);
 
@@ -60,6 +61,21 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
                 vm.toggle = toggle;
                 vm.toggleChecked = vm.items.every(item => item.checked);
             }
+
+            var events = [];
+
+            events.push(eventsService.on("contentment.update.value", (event, args) => {
+                if (args.alias === $scope.model.alias) {
+                    $scope.model.value = args.value;
+                    init();
+                }
+            }));
+
+            $scope.$on("$destroy", () => {
+                for (var event in events) {
+                    eventsService.unsubscribe(events[event]);
+                }
+            });
         };
 
         function changed(item) {

--- a/src/Umbraco.Community.Contentment/DataEditors/DropdownList/dropdown-list.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/DropdownList/dropdown-list.js
@@ -1,11 +1,12 @@
-﻿/* Copyright © 2019 Lee Kelleher.
+/* Copyright © 2019 Lee Kelleher.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.DropdownList.Controller", [
     "$scope",
-    function ($scope) {
+    "eventsService",
+    function ($scope, eventsService) {
 
         //console.log("dropdown-list.model", $scope.model);
 
@@ -20,7 +21,6 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
         var vm = this;
 
         function init() {
-
             config.showEmpty = Object.toBoolean(config.allowEmpty);
 
             vm.items = config.items.slice();
@@ -44,6 +44,21 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
                 : $scope.model.alias;
 
             vm.change = change;
+
+            var events = [];
+
+            events.push(eventsService.on("contentment.update.value", (event, args) => {
+                if (args.alias === $scope.model.alias) {
+                    $scope.model.value = args.value;
+                    init();
+                }
+            }));
+
+            $scope.$on("$destroy", () => {
+                for (var event in events) {
+                    eventsService.unsubscribe(events[event]);
+                }
+            });
         };
 
         function change() {

--- a/src/Umbraco.Community.Contentment/DataEditors/ItemPicker/item-picker.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/ItemPicker/item-picker.js
@@ -1,4 +1,4 @@
-﻿/* Copyright © 2019 Lee Kelleher.
+/* Copyright © 2019 Lee Kelleher.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
@@ -6,10 +6,11 @@
 angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.ItemPicker.Controller", [
     "$scope",
     "editorService",
+    "eventsService",
     "focusService",
     "localizationService",
     "overlayService",
-    function ($scope, editorService, focusService, localizationService, overlayService) {
+    function ($scope, editorService, eventsService, focusService, localizationService, overlayService) {
 
         // console.log("item-picker.model", $scope.model);
 
@@ -36,7 +37,6 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
         var vm = this;
 
         function init() {
-
             $scope.model.value = $scope.model.value || config.defaultValue;
 
             if (Array.isArray($scope.model.value) === false) {
@@ -108,10 +108,24 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
                     $scope.umbProperty.setPropertyActions(vm.propertyActions);
                 }
             }
+
+            var events = [];
+
+            events.push(eventsService.on("contentment.update.value", (event, args) => {
+                if (args.alias === $scope.model.alias) {
+                    $scope.model.value = args.value;
+                    init();
+                }
+            }));
+
+            $scope.$on("$destroy", () => {
+                for (var event in events) {
+                    eventsService.unsubscribe(events[event]);
+                }
+            });
         };
 
         function add() {
-
             focusService.rememberFocus();
 
             var items = Object.toBoolean(config.allowDuplicates)

--- a/src/Umbraco.Community.Contentment/DataEditors/RadioButtonList/radio-button-list.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/RadioButtonList/radio-button-list.js
@@ -1,11 +1,12 @@
-﻿/* Copyright © 2019 Lee Kelleher.
+/* Copyright © 2019 Lee Kelleher.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.RadioButtonList.Controller", [
     "$scope",
-    function ($scope) {
+    "eventsService",
+    function ($scope, eventsService) {
 
         // console.log("radiobuttonlist.model", $scope.model);
 
@@ -55,6 +56,21 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
                     $scope.umbProperty.setPropertyActions(vm.propertyActions);
                 }
             }
+
+            var events = [];
+
+            events.push(eventsService.on("contentment.update.value", (event, args) => {
+                if (args.alias === $scope.model.alias) {
+                    $scope.model.value = args.value;
+                    init();
+                }
+            }));
+
+            $scope.$on("$destroy", () => {
+                for (var event in events) {
+                    eventsService.unsubscribe(events[event]);
+                }
+            });
         };
 
         init();

--- a/src/Umbraco.Community.Contentment/DataEditors/Tags/tags.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/Tags/tags.js
@@ -1,4 +1,4 @@
-﻿/* Copyright © 2021 Lee Kelleher.
+/* Copyright © 2021 Lee Kelleher.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
@@ -9,9 +9,10 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
     "$element",
     "angularHelper",
     "assetsService",
+    "eventsService",
     "localizationService",
     "overlayService",
-    function ($rootScope, $scope, $element, angularHelper, assetsService, localizationService, overlayService) {
+    function ($rootScope, $scope, $element, angularHelper, assetsService, eventsService, localizationService, overlayService) {
 
         //console.log("tags.model", $scope.model);
 
@@ -114,6 +115,21 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
                     $scope.umbProperty.setPropertyActions(vm.propertyActions);
                 }
             }
+
+            var events = [];
+
+            events.push(eventsService.on("contentment.update.value", (event, args) => {
+                if (args.alias === $scope.model.alias) {
+                    $scope.model.value = args.value;
+                    init();
+                }
+            }));
+
+            $scope.$on("$destroy", () => {
+                for (var event in events) {
+                    eventsService.unsubscribe(events[event]);
+                }
+            });
         };
 
         function add($event, item) {

--- a/src/Umbraco.Community.Contentment/DataEditors/TemplatedList/templated-list.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/TemplatedList/templated-list.js
@@ -1,11 +1,12 @@
-﻿/* Copyright © 2020 Lee Kelleher.
+/* Copyright © 2020 Lee Kelleher.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.TemplatedList.Controller", [
     "$scope",
-    function ($scope) {
+    "eventsService",
+    function ($scope, eventsService) {
 
         //console.log("templated-list.model", $scope.model);
 
@@ -69,6 +70,21 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
                     $scope.umbProperty.setPropertyActions(vm.propertyActions);
                 }
             }
+
+            var events = [];
+
+            events.push(eventsService.on("contentment.update.value", (event, args) => {
+                if (args.alias === $scope.model.alias) {
+                    $scope.model.value = args.value;
+                    init();
+                }
+            }));
+
+            $scope.$on("$destroy", () => {
+                for (var event in events) {
+                    eventsService.unsubscribe(events[event]);
+                }
+            });
         };
 
         function clear() {


### PR DESCRIPTION
### Description

> [!NOTE]
> This feature is for Contentment v5 on Umbraco v13 using AngularJS backoffice.
> For Contentment v6 on Umbraco v14+, this feature is not required as the backoffice supports property datasets.

Following the discussion on #416, it would be useful to have a way update/set the items of a Data List editor by using an AngularJS event.

This PR adds an event with the name `"contentment.update.value"`, which can set the value of a Data List's list-editor. The payload must contain both the `alias` of the target property and the `value` (typically a `string` or `string[]`).

An example of how it could be used by a third-party extension:
```
eventsService.emit("contentment.update.value", { alias: "currencies", value: ["USD", "GBP, "DKK"] });
```

### Related Issues?

- https://github.com/leekelleher/umbraco-contentment/discussions/416

### Types of changes

- [x] New feature _(non-breaking change which adds functionality)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
