### PR TITLE
Data List/Picker: Adds data-source support for Delivery API

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataListValueConverter.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataListValueConverter.cs
@@ -8,11 +8,12 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.PropertyEditors.DeliveryApi;
 using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class DataListValueConverter : PropertyValueConverterBase
+    public sealed class DataListValueConverter : PropertyValueConverterBase, IDeliveryApiPropertyValueConverter
     {
         private readonly Type _defaultObjectType = typeof(string);
         private readonly ConfigurationEditorUtility _utility;
@@ -25,14 +26,7 @@ namespace Umbraco.Community.Contentment.DataEditors
 
         public override bool IsConverter(IPublishedPropertyType propertyType) => propertyType.EditorAlias.InvariantEquals(DataListDataEditor.DataEditorAlias);
 
-        public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
-        {
-            TryGetPropertyTypeConfiguration(propertyType, out var hasMultipleValues, out var valueType, out _);
-
-            return hasMultipleValues == true
-                ? typeof(List<>).MakeGenericType(valueType)
-                : valueType;
-        }
+        public override Type GetPropertyValueType(IPublishedPropertyType propertyType) => GetPropertyValueTypeImpl(propertyType, isDeliveryApi: false);
 
         public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Snapshot;
 
@@ -51,9 +45,90 @@ namespace Umbraco.Community.Contentment.DataEditors
             return base.ConvertSourceToIntermediate(owner, propertyType, source, preview);
         }
 
-        public override object? ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+        public override object? ConvertIntermediateToObject(
+            IPublishedElement owner,
+            IPublishedPropertyType propertyType,
+            PropertyCacheLevel referenceCacheLevel,
+            object? inter,
+            bool preview) => ConvertIntermediateToObjectImpl(owner, propertyType, referenceCacheLevel, inter, preview, isDeliveryApi: false, expanding: false);
+
+        public PropertyCacheLevel GetDeliveryApiPropertyCacheLevel(IPublishedPropertyType propertyType) => GetPropertyCacheLevel(propertyType);
+
+        public Type GetDeliveryApiPropertyValueType(IPublishedPropertyType propertyType) => GetPropertyValueTypeImpl(propertyType, isDeliveryApi: true);
+
+        public object? ConvertIntermediateToDeliveryApiObject(
+            IPublishedElement owner,
+            IPublishedPropertyType propertyType,
+            PropertyCacheLevel referenceCacheLevel,
+            object? inter,
+            bool preview,
+            bool expanding) => ConvertIntermediateToObjectImpl(owner, propertyType, referenceCacheLevel, inter, preview, isDeliveryApi: true, expanding);
+
+        private void TryGetPropertyTypeConfiguration(
+            IPublishedPropertyType propertyType,
+            out bool hasMultipleValues,
+            out Type valueType,
+            out Func<Type, string, object?>? converter,
+            bool isDeliveryApi = false,
+            bool expanding = false)
         {
-            TryGetPropertyTypeConfiguration(propertyType, out var hasMultipleValues, out var valueType, out var converter);
+            hasMultipleValues = false;
+            valueType = _defaultObjectType;
+            converter = default;
+
+            if (propertyType.DataType.Configuration is Dictionary<string, object> configuration &&
+                configuration.TryGetValue(DataListConfigurationEditor.DataSource, out var tmp1) == true &&
+                tmp1 is JArray array1 && array1.Count > 0 && array1[0] is JObject obj1 &&
+                obj1.Value<string>("key") is string key1 &&
+                configuration.TryGetValue(DataListConfigurationEditor.ListEditor, out var tmp2) == true &&
+                tmp2 is JArray array2 && array2.Count > 0 && array2[0] is JObject obj2 &&
+                obj2.Value<string>("key") is string key2)
+            {
+                var source = _utility.GetConfigurationEditor<IDataSourceValueConverter>(key1);
+                if (source is not null)
+                {
+                    var config = obj1["value"]?.ToObject<Dictionary<string, object>>();
+
+                    if (isDeliveryApi && source is IDataSourceDeliveryApiValueConverter deliveryApiSource)
+                    {
+                        valueType = deliveryApiSource.GetDeliveryApiValueType(config) ?? _defaultObjectType;
+                        converter = (t, v) => deliveryApiSource.ConvertToDeliveryApiValue(t, v, expanding);
+                    }
+                    else
+                    {
+                        valueType = source.GetValueType(config) ?? _defaultObjectType;
+                        converter = source.ConvertValue;
+                    }
+                }
+
+                var editor = _utility.GetConfigurationEditor<IDataListEditor>(key2);
+                if (editor is not null)
+                {
+                    var config = obj2["value"]?.ToObject<Dictionary<string, object>>();
+                    hasMultipleValues = editor.HasMultipleValues(config);
+                }
+            }
+        }
+
+        private Type GetPropertyValueTypeImpl(IPublishedPropertyType propertyType, bool isDeliveryApi)
+        {
+            TryGetPropertyTypeConfiguration(propertyType, out var hasMultipleValues, out var valueType, out _, isDeliveryApi);
+
+            return hasMultipleValues == true
+                ? typeof(List<>).MakeGenericType(valueType)
+                : valueType;
+        }
+
+        private object? ConvertIntermediateToObjectImpl(
+            IPublishedElement owner,
+            IPublishedPropertyType propertyType,
+            PropertyCacheLevel referenceCacheLevel,
+            object? inter,
+            bool preview,
+            bool isDeliveryApi,
+            bool expanding)
+        {
+            TryGetPropertyTypeConfiguration(propertyType, out var hasMultipleValues, out var valueType, out var converter, isDeliveryApi, expanding);
 
             if (inter is string value)
             {
@@ -128,37 +203,6 @@ namespace Umbraco.Community.Contentment.DataEditors
             }
 
             return base.ConvertIntermediateToObject(owner, propertyType, referenceCacheLevel, inter, preview);
-        }
-
-        private void TryGetPropertyTypeConfiguration(IPublishedPropertyType propertyType, out bool hasMultipleValues, out Type valueType, out Func<Type, string, object>? converter)
-        {
-            hasMultipleValues = false;
-            valueType = _defaultObjectType;
-            converter = default;
-
-            if (propertyType.DataType.Configuration is Dictionary<string, object> configuration &&
-                configuration.TryGetValue(DataListConfigurationEditor.DataSource, out var tmp1) == true &&
-                tmp1 is JArray array1 && array1.Count > 0 && array1[0] is JObject obj1 &&
-                obj1.Value<string>("key") is string key1 &&
-                configuration.TryGetValue(DataListConfigurationEditor.ListEditor, out var tmp2) == true &&
-                tmp2 is JArray array2 && array2.Count > 0 && array2[0] is JObject obj2 &&
-                obj2.Value<string>("key") is string key2)
-            {
-                var source = _utility.GetConfigurationEditor<IDataSourceValueConverter>(key1);
-                if (source is not null)
-                {
-                    var config = obj1["value"]?.ToObject<Dictionary<string, object>>();
-                    valueType = source.GetValueType(config) ?? _defaultObjectType;
-                    converter = source.ConvertValue!;
-                }
-
-                var editor = _utility.GetConfigurationEditor<IDataListEditor>(key2);
-                if (editor is not null)
-                {
-                    var config = obj2["value"]?.ToObject<Dictionary<string, object>>();
-                    hasMultipleValues = editor.HasMultipleValues(config);
-                }
-            }
         }
     }
 }

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentTypesDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentTypesDataListSource.cs
@@ -15,7 +15,8 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class UmbracoContentTypesDataListSource : DataListToDataPickerSourceBridge, IDataListSource, IDataSourceValueConverter
+    public sealed class UmbracoContentTypesDataListSource
+        : DataListToDataPickerSourceBridge, IDataListSource, IDataSourceValueConverter, IDataSourceDeliveryApiValueConverter
     {
         private readonly IContentTypeService _contentTypeService;
         private readonly IUmbracoContextAccessor _umbracoContextAccessor;
@@ -146,5 +147,10 @@ namespace Umbraco.Community.Contentment.DataEditors
 
             return default;
         }
+
+        public Type? GetDeliveryApiValueType(Dictionary<string, object>? config) => typeof(string);
+
+        public object? ConvertToDeliveryApiValue(Type type, string value, bool expanding = false)
+            => ConvertValue(type, value) is IPublishedContentType contentType ? contentType.Alias : value;
     }
 }

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoUserGroupDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoUserGroupDataListSource.cs
@@ -9,7 +9,8 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class UmbracoUserGroupDataListSource : DataListToDataPickerSourceBridge, IDataListSource, IDataSourceValueConverter
+    public sealed class UmbracoUserGroupDataListSource
+        : DataListToDataPickerSourceBridge, IDataListSource, IDataSourceValueConverter, IDataSourceDeliveryApiValueConverter
     {
         private readonly IUserService _userService;
 
@@ -48,5 +49,9 @@ namespace Umbraco.Community.Contentment.DataEditors
         public Type? GetValueType(Dictionary<string, object>? config) => typeof(IUserGroup);
 
         public object? ConvertValue(Type type, string value) => _userService.GetUserGroupByAlias(value);
+
+        public Type? GetDeliveryApiValueType(Dictionary<string, object>? config) => typeof(string);
+
+        public object? ConvertToDeliveryApiValue(Type type, string value, bool expanding = false) => value;
     }
 }

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoUsersDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoUsersDataListSource.cs
@@ -12,7 +12,8 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    public sealed class UmbracoUsersDataListSource : DataListToDataPickerSourceBridge, IDataListSource, IDataSourceValueConverter
+    public sealed class UmbracoUsersDataListSource
+        : DataListToDataPickerSourceBridge, IDataListSource, IDataSourceValueConverter, IDataSourceDeliveryApiValueConverter
     {
         private readonly IIOHelper _ioHelper;
         private readonly IUserService _userService;
@@ -99,5 +100,9 @@ namespace Umbraco.Community.Contentment.DataEditors
         public Type? GetValueType(Dictionary<string, object>? config) => typeof(IUser);
 
         public object? ConvertValue(Type type, string value) => _userService.GetByUsername(value);
+
+        public Type? GetDeliveryApiValueType(Dictionary<string, object>? config) => typeof(string);
+
+        public object? ConvertToDeliveryApiValue(Type type, string value, bool expanding = false) => value;
     }
 }

--- a/src/Umbraco.Community.Contentment/DataEditors/DataPicker/DataPickerValueConverter.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataPicker/DataPickerValueConverter.cs
@@ -7,13 +7,15 @@ using System.Collections;
 using Newtonsoft.Json.Linq;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.PropertyEditors.DeliveryApi;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
-    internal sealed class DataPickerValueConverter : PropertyValueConverterBase
+    internal sealed class DataPickerValueConverter : PropertyValueConverterBase, IDeliveryApiPropertyValueConverter
     {
+        private readonly Type _defaultObjectType = typeof(string);
         private readonly IJsonSerializer _jsonSerializer;
         private readonly ConfigurationEditorUtility _utility;
 
@@ -27,14 +29,7 @@ namespace Umbraco.Community.Contentment.DataEditors
 
         public override bool IsConverter(IPublishedPropertyType propertyType) => propertyType.EditorAlias.InvariantEquals(DataPickerDataEditor.DataEditorAlias);
 
-        public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
-        {
-            TryGetPropertyTypeConfiguration(propertyType, out var hasMultipleValues, out var valueType, out _);
-
-            return hasMultipleValues == true
-                ? typeof(List<>).MakeGenericType(valueType)
-                : valueType;
-        }
+        public override Type GetPropertyValueType(IPublishedPropertyType propertyType) => GetPropertyValueTypeImpl(propertyType, isDeliveryApi: false);
 
         public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Snapshot;
 
@@ -53,9 +48,82 @@ namespace Umbraco.Community.Contentment.DataEditors
             return base.ConvertSourceToIntermediate(owner, propertyType, source, preview);
         }
 
-        public override object? ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+        public override object? ConvertIntermediateToObject(
+            IPublishedElement owner,
+            IPublishedPropertyType propertyType,
+            PropertyCacheLevel referenceCacheLevel,
+            object? inter,
+            bool preview) => ConvertIntermediateToObjectImpl(owner, propertyType, referenceCacheLevel, inter, preview, isDeliveryApi: false, expanding: false);
+
+        public PropertyCacheLevel GetDeliveryApiPropertyCacheLevel(IPublishedPropertyType propertyType) => GetPropertyCacheLevel(propertyType);
+
+        public Type GetDeliveryApiPropertyValueType(IPublishedPropertyType propertyType) => GetPropertyValueTypeImpl(propertyType, isDeliveryApi: true);
+
+        public object? ConvertIntermediateToDeliveryApiObject(
+            IPublishedElement owner,
+            IPublishedPropertyType propertyType,
+            PropertyCacheLevel referenceCacheLevel,
+            object? inter,
+            bool preview,
+            bool expanding) => ConvertIntermediateToObjectImpl(owner, propertyType, referenceCacheLevel, inter, preview, isDeliveryApi: true, expanding);
+
+        private void TryGetPropertyTypeConfiguration(
+            IPublishedPropertyType propertyType,
+            out bool hasMultipleValues,
+            out Type valueType,
+            out Func<Type, string, object?>? converter,
+            bool isDeliveryApi = false,
+            bool expanding = false)
         {
-            TryGetPropertyTypeConfiguration(propertyType, out var hasMultipleValues, out var valueType, out var converter);
+            hasMultipleValues = false;
+            valueType = _defaultObjectType;
+            converter = default;
+
+            if (propertyType.DataType.Configuration is Dictionary<string, object> configuration &&
+                configuration.TryGetValue(DataPickerConfigurationEditor.DataSource, out var tmp1) == true &&
+                tmp1 is JArray array1 && array1.Count > 0 && array1[0] is JObject obj1 &&
+                obj1.Value<string>("key") is string key1)
+            {
+                var source = _utility.GetConfigurationEditor<IDataSourceValueConverter>(key1);
+                if (source is not null)
+                {
+                    var config = obj1["value"]?.ToObject<Dictionary<string, object>>();
+
+                    if (isDeliveryApi && source is IDataSourceDeliveryApiValueConverter deliveryApiSource)
+                    {
+                        valueType = deliveryApiSource.GetDeliveryApiValueType(config) ?? _defaultObjectType;
+                        converter = (t, v) => deliveryApiSource.ConvertToDeliveryApiValue(t, v, expanding);
+                    }
+                    else
+                    {
+                        valueType = source.GetValueType(config) ?? _defaultObjectType;
+                        converter = source.ConvertValue;
+                    }
+                }
+
+                hasMultipleValues = configuration.TryGetValue("maxItems", out var tmp2) == true && tmp2.TryConvertTo<int>().ResultOr(0) != 1;
+            }
+        }
+
+        private Type GetPropertyValueTypeImpl(IPublishedPropertyType propertyType, bool isDeliveryApi)
+        {
+            TryGetPropertyTypeConfiguration(propertyType, out var hasMultipleValues, out var valueType, out _, isDeliveryApi);
+
+            return hasMultipleValues == true
+                ? typeof(List<>).MakeGenericType(valueType)
+                : valueType;
+        }
+
+        private object? ConvertIntermediateToObjectImpl(
+            IPublishedElement owner,
+            IPublishedPropertyType propertyType,
+            PropertyCacheLevel referenceCacheLevel,
+            object? inter,
+            bool preview,
+            bool isDeliveryApi,
+            bool expanding)
+        {
+            TryGetPropertyTypeConfiguration(propertyType, out var hasMultipleValues, out var valueType, out var converter, isDeliveryApi, expanding);
 
             if (inter is string value)
             {
@@ -77,7 +145,7 @@ namespace Umbraco.Community.Contentment.DataEditors
             // ref: https://github.com/leekelleher/umbraco-contentment/issues/111#issuecomment-847780287
             if (inter is JArray array)
             {
-                inter = array.ToObject<IEnumerable<string>>();
+                inter = array.ToObject<IEnumerable<string>>() ?? Enumerable.Empty<string>();
             }
 
             if (inter is IEnumerable<string> items)
@@ -130,29 +198,6 @@ namespace Umbraco.Community.Contentment.DataEditors
             }
 
             return base.ConvertIntermediateToObject(owner, propertyType, referenceCacheLevel, inter, preview);
-        }
-
-        private void TryGetPropertyTypeConfiguration(IPublishedPropertyType propertyType, out bool hasMultipleValues, out Type valueType, out Func<Type, string, object>? converter)
-        {
-            hasMultipleValues = false;
-            valueType = typeof(string);
-            converter = default;
-
-            if (propertyType.DataType.Configuration is Dictionary<string, object> configuration &&
-                configuration.TryGetValue(DataPickerConfigurationEditor.DataSource, out var tmp1) == true &&
-                tmp1 is JArray array1 && array1.Count > 0 && array1[0] is JObject obj1 &&
-                obj1.Value<string>("key") is string key1)
-            {
-                var source = _utility.GetConfigurationEditor<IDataSourceValueConverter>(key1);
-                if (source != null)
-                {
-                    var config = obj1["value"]?.ToObject<Dictionary<string, object>>();
-                    valueType = source.GetValueType(config) ?? typeof(string);
-                    converter = source.ConvertValue!;
-                }
-
-                hasMultipleValues = configuration.TryGetValue("maxItems", out var tmp2) == true && tmp2.TryConvertTo<int>().ResultOr(0) != 1;
-            }
         }
     }
 }

--- a/src/Umbraco.Community.Contentment/DataEditors/_/DataSources/IDataSourceDeliveryApiValueConverter.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/_/DataSources/IDataSourceDeliveryApiValueConverter.cs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2024 Lee Kelleher
+
+namespace Umbraco.Community.Contentment.DataEditors;
+
+public interface IDataSourceDeliveryApiValueConverter : IDataSourceValueConverter
+{
+    Type? GetDeliveryApiValueType(Dictionary<string, object>? config);
+
+    object? ConvertToDeliveryApiValue(Type type, string value, bool expanding = false);
+}


### PR DESCRIPTION
### Description

Following up on the  #427 discussion, this PR adds support for the Umbraco Delivery API to Data List/Picker data-sources.

Thanks to @markadrake's [bug reproduction repository](https://github.com/markadrake/contentment-demo-issue) and @vsilvar's [workaround patch](https://github.com/markadrake/contentment-demo-issue/pull/1), I have introduced an interface `IDataSourceDeliveryApiValueConverter` that can be used on data-sources to provide bespoke value-types for the Delivery API endpoints.

I have implemented this on the following built-in data-sources, (that have more complex value-types):
- `UmbracoContentDataListSource`
- `UmbracoContentTypesDataListSource`
- `UmbracoContentXPathDataListSource`
- `UmbracoMembersDataListSource`
- `UmbracoUserGroupDataListSource`
- `UmbracoUsersDataListSource`

### Types of changes

- [x] New feature _(non-breaking change which adds functionality)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
