### PR TITLE
`ContentmentContentContext`: Adds support for `Guid` IDs 

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/ExamineDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/ExamineDataListSource.cs
@@ -5,6 +5,7 @@
 
 using Examine;
 using Examine.Search;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
@@ -195,6 +196,15 @@ namespace Umbraco.Community.Contentment.DataEditors
                             if (udi.Success == true)
                             {
                                 luceneQuery = string.Format(luceneQuery, udi.Result);
+                            }
+                        }
+                        else if (_contentmentContentContext is IContentmentContentContext2 ctx2)
+                        {
+                            var contentKey = ctx2.GetCurrentContentId<Guid?>(out _);
+                            if (contentKey.HasValue == true)
+                            {
+                                var udi = new GuidUdi(UmbConstants.UdiEntityType.Document, contentKey.Value);
+                                luceneQuery = string.Format(luceneQuery, udi);
                             }
                         }
                     }

--- a/src/Umbraco.Community.Contentment/Services/ContentmentContentContext.cs
+++ b/src/Umbraco.Community.Contentment/Services/ContentmentContentContext.cs
@@ -5,13 +5,14 @@
 
 using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.Services
 {
-    public sealed class ContentmentContentContext : IContentmentContentContext
+    public sealed class ContentmentContentContext : IContentmentContentContext2
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IRequestAccessor _requestAccessor;
@@ -27,40 +28,43 @@ namespace Umbraco.Community.Contentment.Services
             _umbracoContextAccessor = umbracoContextAccessor;
         }
 
-        public int? GetCurrentContentId(out bool isParent)
+        public T? GetCurrentContentId<T>(out bool isParent)
         {
             isParent = false;
 
-            if (_umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext) == true)
+            if (_umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext) == true &&
+                umbracoContext.PublishedRequest?.PublishedContent is not null)
             {
-                if (umbracoContext.PublishedRequest?.PublishedContent != null)
+                var attempt = umbracoContext.PublishedRequest.PublishedContent.Id.TryConvertTo<T>();
+                if (attempt.Success)
                 {
-                    isParent = false;
-                    return umbracoContext.PublishedRequest.PublishedContent.Id;
+                    return attempt.Result;
                 }
             }
 
             // NOTE: First we check for "id" (if on a content page), then "parentId" (if editing an element).
-            if (int.TryParse(_requestAccessor.GetRequestValue("id"), out var currentId) == true)
+            var attempt1 = _requestAccessor.GetRequestValue("id")?.TryConvertTo<T>() ?? Attempt.Fail<T>();
+            if (attempt1.Success)
             {
-                return currentId;
+                return attempt1.Result;
             }
-            else if (int.TryParse(_requestAccessor.GetRequestValue("parentId"), out var parentId) == true)
+
+            var attempt2 = _requestAccessor.GetRequestValue("parentId")?.TryConvertTo<T>() ?? Attempt.Fail<T>();
+            if (attempt2.Success)
             {
                 isParent = true;
-
-                return parentId;
+                return attempt2.Result;
             }
 
             var json = _httpContextAccessor.HttpContext?.Request.GetRawBodyStringAsync().GetAwaiter().GetResult();
             if (string.IsNullOrWhiteSpace(json) == false)
             {
-                var obj = JsonConvert.DeserializeAnonymousType(json, new { id = 0, parentId = 0 });
-                if (obj?.id > 0)
+                var obj = JsonConvert.DeserializeAnonymousType(json, new { id = default(T), parentId = default(T) });
+                if (obj is not null && obj.id is not null)
                 {
                     return obj.id;
                 }
-                else if (obj?.parentId > 0)
+                else if (obj is not null && obj.parentId is not null)
                 {
                     isParent = true;
                     return obj.parentId;
@@ -69,6 +73,8 @@ namespace Umbraco.Community.Contentment.Services
 
             return default;
         }
+
+        public int? GetCurrentContentId(out bool isParent) => GetCurrentContentId<int>(out isParent);
 
         public IPublishedContent? GetCurrentContent(out bool isParent)
         {
@@ -81,11 +87,20 @@ namespace Umbraco.Community.Contentment.Services
                     return umbracoContext.PublishedRequest.PublishedContent;
                 }
 
-                var currentContentId = GetCurrentContentId(out isParent);
+                // NOTE: First we check for an integer ID.
+                var currentContentId = GetCurrentContentId<int?>(out isParent);
 
                 if (currentContentId.HasValue == true)
                 {
                     return umbracoContext.Content?.GetById(true, currentContentId.Value);
+                }
+
+                // NOTE: Next we check for a GUID ID.
+                var currentContentKey = GetCurrentContentId<Guid?>(out isParent);
+
+                if (currentContentKey.HasValue == true)
+                {
+                    return umbracoContext.Content?.GetById(true, currentContentKey.Value);
                 }
             }
 

--- a/src/Umbraco.Community.Contentment/Services/IContentmentContentContext.cs
+++ b/src/Umbraco.Community.Contentment/Services/IContentmentContentContext.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright © 2022 Lee Kelleher.
+/* Copyright © 2022 Lee Kelleher.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
@@ -12,5 +12,11 @@ namespace Umbraco.Community.Contentment.Services
         int? GetCurrentContentId(out bool isParent);
 
         IPublishedContent? GetCurrentContent(out bool isParent);
+    }
+
+    // NOTE: Added as a separate interface, so not to break binary backwards-compatibility. [LK]
+    public interface IContentmentContentContext2 : IContentmentContentContext
+    {
+        T? GetCurrentContentId<T>(out bool isParent);
     }
 }


### PR DESCRIPTION
### Description

Refactors `ContentmentContentContext` to add support for handling `Guid` IDs.

An interface `IContentmentContentContext2` (note the "2" suffix) has been added in order to maintain binary compatibility, making it opt-in for any existing 3rd-party implementations of `IContentmentContentContext`.

### Related Issues?

- #433

### Types of changes

- [x] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_

### Checklist

- [x My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [x I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
