### PR TITLE
Data List: Buttons: Enable deselection of single buttons

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/Buttons/buttons.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/Buttons/buttons.js
@@ -112,7 +112,7 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
             vm.items.forEach(x => {
 
                 if (vm.multiple === false) {
-                    x.selected = x.value === item.value;
+                    x.selected = item.selected && x.value === item.value;
                 }
 
                 if (x.selected) {

--- a/src/Umbraco.Community.Contentment/DataEditors/TemplatedList/templated-list.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/TemplatedList/templated-list.js
@@ -102,7 +102,7 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
             vm.items.forEach(x => {
 
                 if (vm.multiple === false) {
-                    x.selected = x.value === item.value;
+                    x.selected = item.selected && x.value === item.value;
                 }
 
                 if (x.selected) {


### PR DESCRIPTION
### Description

As discussed in https://github.com/leekelleher/umbraco-contentment/discussions/435, here's a fix that enables deselection of buttons (and buttons in templated list), when not enabling multi selection.

### Related Issues?

- https://github.com/leekelleher/umbraco-contentment/discussions/435

### Types of changes

- [x] Bug fix _(non-breaking change which fixes an issue)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
