### PR TITLE
V6: Data List: Buttons: Enables deselection of single button

### DIFF
--- a/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/buttons/buttons.element.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/buttons/buttons.element.ts
@@ -73,7 +73,7 @@ export class ContentmentPropertyEditorUIButtonsElement extends UmbLitElement imp
 
 		this._items.forEach((item) => {
 			if (!this._enableMultiple) {
-				item.selected = item.value === option.value;
+				item.selected = option.selected && item.value === option.value;
 			}
 
 			if (item.selected) {

--- a/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/templated-list/templated-list.element.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/templated-list/templated-list.element.ts
@@ -107,7 +107,7 @@ export class ContentmentPropertyEditorUITemplatedListElement
 
 		this._items.forEach((item) => {
 			if (!this._enableMultiple) {
-				item.selected = item.value === option.value;
+				item.selected = option.selected && item.value === option.value;
 			}
 
 			if (item.selected) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

### Description

As discussed in https://github.com/leekelleher/umbraco-contentment/discussions/435, heres a fix that enables deselection of buttons (and buttons in templated list), when not enabling multi selection.

This PR is for v6, #436 is for v5.

I couldn't get the demo site going for some reason, but the change is simple, so I thought YOLO :)

### Related Issues?

https://github.com/leekelleher/umbraco-contentment/discussions/435

### Types of changes

- [x] Bug fix _(non-breaking change which fixes an issue)_

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
