### PR TITLE
Content Blocks: Sets `key` of copied blocks

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/content-blocks.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/content-blocks.js
@@ -224,6 +224,7 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
                     config.elementTypeScaffoldCache[elementType.alias] = scaffold;
                 }
 
+                scaffold.key = item.key;
                 scaffold.name = name;
                 scaffold.variants[0].name = name;
 

--- a/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/content-blocks.overlay.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/content-blocks.overlay.js
@@ -46,11 +46,7 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.Overlays.Con
                 vm.items = config.elementTypes;
                 vm.selectedElementType = null;
 
-                // NOTE: Corrected `retriveDataOfType` typo, but kept backwards-compatibility for v8.17.x.
-                // ref: https://github.com/umbraco/Umbraco-CMS/pull/11027
-                vm.clipboardItems = typeof clipboardService.retrieveDataOfType === "function"
-                    ? clipboardService.retrieveDataOfType("elementType", config.elementTypes.map(item => item.alias))
-                    : clipboardService.retriveDataOfType("elementType", config.elementTypes.map(item => item.alias));
+                vm.clipboardItems = clipboardService.retrieveDataOfType("elementType", config.elementTypes.map(item => item.alias));
 
                 if (config.elementTypes.length > 1 || vm.clipboardItems.length > 0) {
 


### PR DESCRIPTION
### Description

Fixes #432.

When copying a Content Block item, the scaffold/schema is being requested (and later stored in a local cache), but the value for the `key` was being generated for the initial scaffold and not being updated per copied block item, which meant that any subsequent copied block items of the same element-type would replace the previously copied block item.

This PR fixes this by explicitly setting the `key` of the freshly copied block item.

### Related Issues?

- #432

### Types of changes

- [x] Bug fix _(non-breaking change which fixes an issue)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
