### PR TITLE
Icon Picker: Adds "clear selection" action

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/IconPicker/icon-picker.css
+++ b/src/Umbraco.Community.Contentment/DataEditors/IconPicker/icon-picker.css
@@ -1,28 +1,11 @@
-﻿/* Copyright © 2019 Lee Kelleher.
+/* Copyright © 2019 Lee Kelleher.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-.contentment .lk-icon-picker-small {
-    border: 1px dashed #d8d7d9;
-    color: #d8d7d9;
-    display: inline-block;
-    height: 20px;
-    padding: 5px 0;
-    text-align: center;
-    width: 30px;
+.contentment .umb-panel-header-icon .label-add {
+    font-size: 10px;
 }
-
-    .contentment .lk-icon-picker-small:focus,
-    .contentment .lk-icon-picker-small:hover {
-        border-color: #2152a3;
-        color: #2152a3;
-        text-decoration: none;
-    }
-
-    .contentment .lk-icon-picker-small i.color-black {
-        color: #000;
-    }
 
 .contentment .umb-mediapicker .umb-sortable-thumbnails__wrapper > .icon {
     font-size: 50px;

--- a/src/Umbraco.Community.Contentment/DataEditors/IconPicker/icon-picker.html
+++ b/src/Umbraco.Community.Contentment/DataEditors/IconPicker/icon-picker.html
@@ -1,4 +1,4 @@
-﻿<!-- Copyright © 2013-present Umbraco.
+<!-- Copyright © 2013-present Umbraco.
    - This Source Code has been derived from Umbraco CMS.
    - https://github.com/umbraco/Umbraco-CMS/blob/release-8.1.0/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
    - https://github.com/umbraco/Umbraco-CMS/blob/release-8.17.0/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/icon.prevalues.html
@@ -33,10 +33,13 @@
             </ul>
         </div>
     </div>
-    <button ng-if="vm.size === 'small'" type="button" class="btn-reset umb-panel-header-icon" ng-click="vm.pick()" ng-class="{'-placeholder': !model.value }" title="{{model.value}}">
-        <umb-icon icon="{{model.value}}" class="icon" ng-if="model.value"></umb-icon>
-        <span class="umb-panel-header-icon-text" ng-if="!model.value">
-            <localize key="settings_addIcon">Add icon</localize>
-        </span>
-    </button>
+    <div ng-if="vm.size === 'small'" class="flex">
+        <button type="button" class="btn-reset umb-panel-header-icon" ng-click="vm.pick()" ng-class="{'-placeholder': !model.value }" title="{{model.value}}">
+            <umb-icon icon="{{model.value}}" class="icon" ng-if="model.value"></umb-icon>
+            <span class="label-add" ng-if="!model.value">
+                <localize key="settings_addIcon">Add icon</localize>
+            </span>
+        </button>
+        <button ng-if="model.value" aria-label="Remove" type="button" class="btn-reset umb-button--xxs" ng-click="vm.remove()">Clear selection</button>
+    </div>
 </div>

--- a/src/Umbraco.Community.Contentment/DataEditors/IconPicker/icon-picker.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/IconPicker/icon-picker.js
@@ -1,4 +1,4 @@
-﻿/* Copyright © 2019 Lee Kelleher.
+/* Copyright © 2019 Lee Kelleher.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */


### PR DESCRIPTION
### Description

Adds a **Clear selection** button to the Icon Picker property-editor (that has the "small" size configuration).

Fixes #470.

### Types of changes

- [x] Bug fix _(non-breaking change which fixes an issue)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
