### PR TITLE
Data Picker: Passes selected items to the `Search` endpoint

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/DataPicker/IDataPickerSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataPicker/IDataPickerSource.cs
@@ -1,4 +1,4 @@
-/* Copyright © 2023 Lee Kelleher.
+/* Copyright Â© 2023 Lee Kelleher.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
@@ -12,5 +12,16 @@ namespace Umbraco.Community.Contentment.DataEditors
         Task<IEnumerable<DataListItem>> GetItemsAsync(Dictionary<string, object> config, IEnumerable<string> values);
 
         Task<PagedResult<DataListItem>> SearchAsync(Dictionary<string, object> config, int pageNumber = 1, int pageSize = 12, string query = "");
+    }
+
+    // NOTE: Added as a separate interface, so not to break binary backwards-compatibility. [LK]
+    public interface IDataPickerSource2 : IDataPickerSource
+    {
+        Task<PagedResult<DataListItem>> SearchAsync(
+            Dictionary<string, object> config,
+            int pageNumber = 1,
+            int pageSize = 12,
+            string query = "",
+            IEnumerable<string>? values = null);
     }
 }

--- a/src/Umbraco.Community.Contentment/DataEditors/DataPicker/IDataPickerSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataPicker/IDataPickerSource.cs
@@ -11,6 +11,7 @@ namespace Umbraco.Community.Contentment.DataEditors
     {
         Task<IEnumerable<DataListItem>> GetItemsAsync(Dictionary<string, object> config, IEnumerable<string> values);
 
+        [Obsolete("Use `SearchAsync` with the additional `values` parameter instead. This method will be removed in Contentment 7.0.")]
         Task<PagedResult<DataListItem>> SearchAsync(Dictionary<string, object> config, int pageNumber = 1, int pageSize = 12, string query = "");
     }
 

--- a/src/Umbraco.Community.Contentment/DataEditors/DataPicker/data-picker.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataPicker/data-picker.js
@@ -130,6 +130,7 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
                     listType: config.displayMode,
                     maxItems: config.maxItems === 0 ? config.maxItems : config.maxItems - $scope.model.value.length,
                     pageSize: config.pageSize,
+                    selectedItems: $scope.model.value,
                 },
                 submit: function (selection) {
 

--- a/src/Umbraco.Community.Contentment/DataEditors/DataPicker/data-picker.overlay.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataPicker/data-picker.overlay.js
@@ -21,6 +21,7 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.Overlays.Dat
             listType: "cards",
             maxItems: 0,
             pageSize: 12,
+            selectedItems: [],
         };
         var config = Object.assign({}, defaultConfig, $scope.model.config);
 
@@ -69,7 +70,7 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.Overlays.Dat
             vm.loading = true;
 
             umbRequestHelper.resourcePromise(
-                $http.get("backoffice/Contentment/DataPickerApi/Search", {
+                $http.post("backoffice/Contentment/DataPickerApi/Search", config.selectedItems, {
                     params: {
                         id: config.currentPageId,
                         dataTypeKey: vm.searchOptions.dataTypeKey,


### PR DESCRIPTION
### Description

Implements #410.

Updates the Data Picker editor to send any existing/selected values to the `Search` API controller endpoint. This enables a custom/3rd-party data-source to filter out any selected values from the returned results. This needs to be done at data-source level, as to correctly calculate the query filtering and pagination.

So not to introduce a breaking-change to Contentment v5.x branch, _(otherwise it'll mess up the work I've done with v6.x for Umbraco Bellissima),_ I have introduced this feature as temporary opt-in interface, `IDataPickerSource2`. This interface overloads the `SearchAsync` method to add an extra parameter for `IEnumerable<string>? values`.

To implement this in your custom data-source, you would need to implement the `IDataPickerSource2` interface, which would include both `SearchAsync` methods, (with and without the `values` parameter). My aim is to clean-up this interface for Contentment v7.0, (to handle the breaking-change). The simplest way to workaround this is to implement the legacy `SearchAsync` method by passing the parameters directly to the overloaded method.

e.g.

```csharp
public Task<PagedResult<DataListItem>> SearchAsync(Dictionary<string, object> config, int pageNumber = 1, int pageSize = 12, string query = "")
    => SearchAsync(config, pageNumber, pageSize, query, []);

public Task<PagedResult<DataListItem>> SearchAsync(Dictionary<string, object> config, int pageNumber = 1, int pageSize = 12, string query = "", IEnumerable<string>? values = null)
{
    // do your thing!
}
```


### Types of changes

- [x] New feature _(non-breaking change which adds functionality)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [x] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
