### PR TITLE
Fix #480: DataPicker can't find UMB_CONTENT_WORKSPACE_CONTEXT

### DIFF
--- a/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/data-picker/data-picker-modal.element.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/data-picker/data-picker-modal.element.ts
@@ -93,7 +93,7 @@ export class ContentmentPropertyEditorUIDataPickerModalElement extends UmbModalB
 
 		this.consumeContext(UMB_CONTENT_WORKSPACE_CONTEXT, (contentWorkspaceContext) => {
 			this.observe(contentWorkspaceContext?.unique, (unique) => (this._entityUnique = unique || undefined));
-		});
+		}).passContextAliasMatches();
 
 		this.consumeContext(UMB_PROPERTY_TYPE_BASED_PROPERTY_CONTEXT, (context) => {
 			this.observe(context?.dataType, (dataType) => (this._dataTypeKey = dataType?.unique));

--- a/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/data-picker/data-picker.element.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/data-picker/data-picker.element.ts
@@ -100,7 +100,7 @@ export class ContentmentPropertyEditorUIDataPickerElement extends UmbLitElement 
 			this.observe(contentWorkspaceContext?.unique, (unique) => {
 				this._entityUnique = unique;
 			});
-		});
+		}).passContextAliasMatches();
 
 		this.consumeContext(UMB_PROPERTY_TYPE_BASED_PROPERTY_CONTEXT, (context) => {
 			this.observe(context?.dataType, (dataType) => (this._dataTypeKey = dataType?.unique));


### PR DESCRIPTION
### Description

Due to breaking changes with ancestor contexts not being discoverable, the DataPicker GUI has broken.

### Related Issues?

#480 

### Types of changes

Chained `.passContextAliasMatches()` to the `consumeContext` call.

- [ ] Documentation change
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
