### PR TITLE
Block Editor Liquid View

### DIFF
--- a/src/Umbraco.Community.Contentment.Client/package-lock.json
+++ b/src/Umbraco.Community.Contentment.Client/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "umbraco-contentment",
 			"version": "6.0.2",
 			"dependencies": {
-				"liquidjs": "^10.22.0",
+				"liquidjs": "^10.24.0",
 				"sortablejs": "^1.15.6"
 			},
 			"devDependencies": {
@@ -2828,9 +2828,9 @@
 			"peer": true
 		},
 		"node_modules/liquidjs": {
-			"version": "10.22.0",
-			"resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.22.0.tgz",
-			"integrity": "sha512-SGBYxl7U7vqmmAQdP/PTP3P3q11f99xUjdtxVICqNQqPecl+JIMCsTshDObGzicHaAqWAnPW0o25a9hDaJxOng==",
+			"version": "10.24.0",
+			"resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.24.0.tgz",
+			"integrity": "sha512-TAUNAdgwaAXjjcUFuYVJm9kOVH7zc0mTKxsG9t9Lu4qdWjB2BEblyVIYpjWcmJLMGgiYqnGNJjpNMHx0gp/46A==",
 			"license": "MIT",
 			"dependencies": {
 				"commander": "^10.0.0"

--- a/src/Umbraco.Community.Contentment.Client/package.json
+++ b/src/Umbraco.Community.Contentment.Client/package.json
@@ -10,7 +10,7 @@
 		"generate:server-api": "openapi-ts --file openapi-ts.config.js"
 	},
 	"dependencies": {
-		"liquidjs": "^10.22.0",
+		"liquidjs": "^10.24.0",
 		"sortablejs": "^1.15.6"
 	},
 	"peerDependencies": {

--- a/src/Umbraco.Community.Contentment.Client/src/extensions/block-editor-custom-view/index.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/extensions/block-editor-custom-view/index.ts
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+// Copyright © 2025 Lee Kelleher
+
+export type * from './liquid.kind.js';

--- a/src/Umbraco.Community.Contentment.Client/src/extensions/block-editor-custom-view/liquid.element.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/extensions/block-editor-custom-view/liquid.element.ts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+// Copyright © 2025 Lee Kelleher
+
+import { customElement, nothing, property, state, unsafeHTML, until } from '@umbraco-cms/backoffice/external/lit';
+import { Liquid } from '../../external/liquidjs/index.js';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
+import { UMB_BLOCK_ENTRY_CONTEXT } from '@umbraco-cms/backoffice/block';
+import type { ContentmentBlockEditorCustomViewLiquidManifestKind } from './liquid.kind.js';
+import type { Template } from '../../external/liquidjs/index.js';
+import type { UmbBlockDataType, UmbBlockLayoutBaseModel } from '@umbraco-cms/backoffice/block';
+import type {
+	UmbBlockEditorCustomViewConfiguration,
+	UmbBlockEditorCustomViewElement,
+} from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockTypeBaseModel } from '@umbraco-cms/backoffice/block-type';
+
+@customElement('contentment-block-editor-liquid-view')
+export class ContentmentBlockEditorLiquidViewElement extends UmbLitElement implements UmbBlockEditorCustomViewElement {
+	#engine = new Liquid({ cache: true });
+
+	#template?: Array<Template>;
+
+	@state()
+	private _contentElementTypeAlias?: string;
+
+	@property({ attribute: false })
+	public set manifest(value: ContentmentBlockEditorCustomViewLiquidManifestKind | undefined) {
+		this.#manifest = value;
+
+		if (value?.template) {
+			if (typeof value.template === 'function') {
+				value.template().then((result) => {
+					const templateString = typeof result === 'string' ? result : result.default;
+					this.#template = this.#engine.parse(templateString);
+					this.requestUpdate();
+				});
+			} else {
+				this.#template = this.#engine.parse(value.template);
+			}
+		}
+	}
+	public get manifest(): ContentmentBlockEditorCustomViewLiquidManifestKind | undefined {
+		return this.#manifest;
+	}
+	#manifest?: ContentmentBlockEditorCustomViewLiquidManifestKind | undefined;
+
+	@property({ attribute: false })
+	config?: UmbBlockEditorCustomViewConfiguration;
+
+	@property({ attribute: false })
+	blockType?: UmbBlockTypeBaseModel;
+
+	@property({ attribute: false })
+	contentKey?: string;
+
+	@property({ attribute: false })
+	label?: string;
+
+	@property({ attribute: false })
+	icon?: string;
+
+	@property({ attribute: false })
+	index?: number;
+
+	@property({ attribute: false })
+	layout?: UmbBlockLayoutBaseModel;
+
+	@property({ attribute: false })
+	content?: UmbBlockDataType;
+
+	@property({ attribute: false })
+	settings?: UmbBlockDataType;
+
+	@property({ attribute: false })
+	contentInvalid?: boolean;
+
+	@property({ attribute: false })
+	settingsInvalid?: boolean;
+
+	@property({ attribute: false })
+	unsupported?: boolean;
+
+	@property({ attribute: false })
+	unpublished?: boolean;
+
+	constructor() {
+		super();
+
+		this.consumeContext(UMB_BLOCK_ENTRY_CONTEXT, (blockEntry) => {
+			this.observe(blockEntry?.contentElementTypeAlias, (contentElementTypeAlias) => {
+				this._contentElementTypeAlias = contentElementTypeAlias;
+			});
+		});
+	}
+
+	override render() {
+		return until(this.#renderTemplate());
+	}
+
+	async #renderTemplate() {
+		if (!this.#engine || !this.#template) return nothing;
+
+		const scope = {
+			manifest: this.manifest,
+			config: this.config,
+			blockType: this.blockType,
+			label: this.label,
+			icon: this.icon,
+			index: this.index,
+			layout: this.layout,
+			content: this.content,
+			settings: this.settings,
+			contentInvalid: this.contentInvalid,
+			settingsInvalid: this.settingsInvalid,
+			unsupported: this.unsupported,
+			unpublished: this.unpublished,
+			contentElementTypeAlias: this._contentElementTypeAlias,
+		};
+
+		const markup = await this.#engine.render(this.#template, scope);
+		return markup ? unsafeHTML(markup) : nothing;
+	}
+
+	static override readonly styles = [UmbTextStyles];
+}
+
+export { ContentmentBlockEditorLiquidViewElement as element };
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'contentment-block-editor-liquid-view': ContentmentBlockEditorLiquidViewElement;
+	}
+}

--- a/src/Umbraco.Community.Contentment.Client/src/extensions/block-editor-custom-view/liquid.kind.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/extensions/block-editor-custom-view/liquid.kind.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+// Copyright © 2025 Lee Kelleher
+
+import type { ManifestBlockEditorCustomView } from '@umbraco-cms/backoffice/block-custom-view';
+
+export interface ContentmentLiquidTemplateModule {
+	default: string;
+}
+
+export interface ContentmentBlockEditorCustomViewLiquidManifestKind extends ManifestBlockEditorCustomView {
+	type: 'blockEditorCustomView';
+	kind: 'liquid';
+	template?: string | (() => Promise<string | ContentmentLiquidTemplateModule>) | null | undefined;
+}
+
+declare global {
+	interface UmbExtensionManifestMap {
+		contentmentBlockEditorCustomViewLiquid: ContentmentBlockEditorCustomViewLiquidManifestKind;
+	}
+}

--- a/src/Umbraco.Community.Contentment.Client/src/extensions/block-editor-custom-view/liquid.kind.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/extensions/block-editor-custom-view/liquid.kind.ts
@@ -10,7 +10,10 @@ export interface ContentmentLiquidTemplateModule {
 export interface ContentmentBlockEditorCustomViewLiquidManifestKind extends ManifestBlockEditorCustomView {
 	type: 'blockEditorCustomView';
 	kind: 'liquid';
+	/** Path to fetch or dynamic import loader */
 	template?: string | (() => Promise<string | ContentmentLiquidTemplateModule>) | null | undefined;
+	/** Inline Liquid template markup (fallback if template fails) */
+	templateContent?: string | null | undefined;
 }
 
 declare global {

--- a/src/Umbraco.Community.Contentment.Client/src/extensions/block-editor-custom-view/manifests.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/extensions/block-editor-custom-view/manifests.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+// Copyright © 2025 Lee Kelleher
+
+import type { ManifestBlockEditorCustomView } from '@umbraco-cms/backoffice/block-custom-view';
+import type { ManifestKind } from '@umbraco-cms/backoffice/extension-api';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+
+const kind: ManifestKind<ManifestBlockEditorCustomView> = {
+	type: 'kind',
+	alias: 'Umb.Contentment.Kind.BlockEditorCustomView.Liquid',
+	matchKind: 'liquid',
+	matchType: 'blockEditorCustomView',
+	manifest: {
+		type: 'blockEditorCustomView',
+		kind: 'liquid',
+		element: () => import('./liquid.element.js'),
+	},
+};
+
+export const manifests: Array<UmbExtensionManifest | UmbExtensionManifestKind> = [kind];

--- a/src/Umbraco.Community.Contentment.Client/src/extensions/manifests.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/extensions/manifests.ts
@@ -1,12 +1,15 @@
-// SPDX-License-Identifier: MPL-2.0
-// Copyright © 2024 Lee Kelleher
+// SPDX-License-Identifier: MIT
+// Copyright © 2025 Lee Kelleher
 
+import { manifests as blockEditorCustomViews } from './block-editor-custom-view/manifests.js';
 import { manifests as dataListItemUis } from './data-list-item-ui/manifests.js';
 import { manifests as dataSources } from './data-source/manifests.js';
 import { manifests as displayModes } from './display-mode/manifests.js';
 import { manifests as listEditors } from './list-editor/manifests.js';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<UmbExtensionManifest> = [
+export const manifests: Array<UmbExtensionManifest | UmbExtensionManifestKind> = [
+	...blockEditorCustomViews,
 	...dataListItemUis,
 	...dataSources,
 	...displayModes,

--- a/src/Umbraco.Community.Contentment.Client/src/extensions/types.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/extensions/types.ts
@@ -1,6 +1,7 @@
-// SPDX-License-Identifier: MPL-2.0
-// Copyright © 2024 Lee Kelleher
+// SPDX-License-Identifier: MIT
+// Copyright © 2025 Lee Kelleher
 
+export type * from './block-editor-custom-view/index.js';
 export type * from './data-list-item-ui/index.js';
 export type * from './data-source/index.js';
 export type * from './display-mode/index.js';

--- a/src/Umbraco.Community.Contentment.Client/src/external/liquidjs/liquid.d.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/external/liquidjs/liquid.d.ts
@@ -1,0 +1,4 @@
+declare module '*.liquid?raw' {
+	const content: string;
+	export default content;
+}

--- a/src/Umbraco.Community.Contentment.Client/src/manifests.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/manifests.ts
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: MPL-2.0
-// Copyright © 2024 Lee Kelleher
+// SPDX-License-Identifier: MIT
+// Copyright © 2025 Lee Kelleher
 
 import { manifests as conditions } from './condition/manifests.js';
 import { manifests as extensions } from './extensions/manifests.js';
@@ -8,10 +8,11 @@ import { manifests as localizations } from './localization/manifests.js';
 import { manifests as propertyActions } from './property-action/manifests.js';
 import { manifests as propertyEditorUis } from './property-editor-ui/manifests.js';
 import { manifests as workspaces } from './workspace/manifests.js';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
 import './components/index.js';
 
-export const manifests: Array<UmbExtensionManifest> = [
+export const manifests: Array<UmbExtensionManifest | UmbExtensionManifestKind> = [
 	...conditions,
 	...extensions,
 	...icons,


### PR DESCRIPTION
### Description

Adds a [Block Custom View](https://docs.umbraco.com/umbraco-cms/customizing/extending-overview/extension-types/block-custom-view) engine for [Liquid.js](https://liquidjs.com).

Here's an example of its usage.

**The manifest**

```ts
export const manifest: ContentmentBlockEditorCustomViewLiquidManifestKind = {
	type: 'blockEditorCustomView',
	kind: 'liquid',
	alias: 'My.BlockEditorCustomView.Liquid',
	name: 'My Liquid Block Editor Custom View',
	forBlockEditor: 'block-list', // or 'block-grid', 'block-rte'
	forContentTypeAlias: ['myElementTypeAlias'],
	template: () => import('./example-template.liquid?raw'), // or path from root, e.g. "/App_Plugins/..."
	templateContent: `<h4>{{ label }}</h4>`, // (optional) inline Liquid.js template
};
```

To note, the `template` property can be either a `string` path to the Liquid.js template file, or a function to load in at runtime.
The `templateContent` can hold an inline Liquid.js template, that can be used as a fallback if the `template` is empty or fails to load.

**The Liquid.js template**

```liquid
<div class="uui-text">
	<h4>{{ label }}</h4>
	<code>Content Key: {{ layout.contentKey }}</code>
	<umb-code-block>{{ content | json: 2 }}</umb-code-block>
</div>

```

### Types of changes

- [x] New feature _(non-breaking change which adds functionality)_

### Checklist

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
