### PR TITLE
Add JsonPropertyName to properties to match ContentmentContentBlockVa…

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlock.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/ContentBlocks/ContentBlock.cs
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+using System.Text.Json.Serialization;
+
 namespace Umbraco.Community.Contentment.DataEditors
 {
     public sealed class ContentBlock
@@ -12,10 +14,13 @@ namespace Umbraco.Community.Contentment.DataEditors
             Value = new Dictionary<string, object?>(StringComparer.InvariantCultureIgnoreCase);
         }
 
+        [JsonPropertyName("elementType")]
         public Guid ElementType { get; set; }
 
+        [JsonPropertyName("key")]
         public Guid Key { get; set; }
 
+        [JsonPropertyName("value")]
         public Dictionary<string, object?> Value { get; set; }
     }
 }


### PR DESCRIPTION
Add JsonPropertyName to properties to match ContentmentContentBlockValue. This fixes an issue where the ContentBlock is not propertly saved on the frontend.

<!-- Provide a general summary of your changes in the Title above -->

### Description

<!-- Please include a summary of the change and which issue is fixed.
     Please also include relevant motivation and context.
     List any dependencies that are required for this change. -->

This changes the way ContentBlocks are serialized. The following interface is expected on the frontend:
`export type ContentmentContentBlockValue = {
	elementType: string;
	key: string;
	value: Record<string, unknown>;
};`
This fixes an issue where ContentBlocks are used in a Umbraco.Community.Contentment.ContentBlocks datatype which is currently broken.

### Related Issues?

<!-- If suggesting a new feature or change, please discuss it in an issue first.
     If fixing a bug for an existing issue, please link to the issue here: -->

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
     Please do not upgrade any NuGet dependencies.
     Please do not modify any licensing information, e.g. do not update the copyright year. -->

- [ ] Documentation change
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
