### PR TITLE
Included TypeScript types in NuGet package.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,3 +46,7 @@ Information about Contentment's [telemetry feature](../docs/telemetry.md).
 #### Tree Dashboard
 
 Information about Contentment's [tree dashboard](../docs/tree-dashboard.md).
+
+#### TypeScript
+
+Information about [referencing Contentment TypeScript types in your own implementations](../docs/typescript.md).

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -1,0 +1,71 @@
+<img src="assets/img/logo.png" alt="Contentment for Umbraco logo" title="A state of Umbraco happiness." height="130" align="right">
+
+## Contentment for Umbraco
+
+### TypeScript
+
+Contentment's types are bundled in the NuGet package's contentFiles.  
+Specifically `contentFiles/any/any/vendor/Contentment/index.d.ts`.
+
+It will be copied automatically to `/vendor/Contentment` in your project.
+
+To opt out, set the msbuild property `Contentment_CopyTypes` to false.
+
+```xml
+<PropertyGroup>
+  <Contentment_CopyTypes>false</Contentment_CopyTypes>
+</PropertyGroup>
+```
+
+It is recommended to add it as an aliased path in your tsconfig.json:
+
+```json
+{
+  "compilerOptions": {
+    // ...
+    "paths": {
+      "@umbraco-community/contentment": ["./../vendor/Contentment/index.d.ts"]
+      // ...
+    }
+  }
+}
+```
+
+### Tests
+
+At the time of writing, the compiled JavaScript is not copied to any projects,
+except on publish with the right options to include Razor Class Library static files.
+
+They may be copied to a test project within an msbuild project using the following task and making sure you have the `GeneratePathProperty` attribute on the package reference:
+
+```xml
+  <PackageReference Include="Umbraco.Community.Contentment" Version="6.*" GeneratePathProperty="true" />
+
+  <Target Name="CopyContentmentBundleForTests">
+    <PropertyGroup>
+      <ContentmentBundleSourcePath>$(PkgUmbraco_Community_Contentment)/staticwebassets/App_Plugins/Contentment</ContentmentBundleSourcePath>
+      <ContentmentBundleDestinationPath>$(MSBuildProjectDirectory)/Client/vendor/contentment</ContentmentBundleDestinationPath>
+    </PropertyGroup>
+    <ItemGroup>
+      <ContentmentBundleFiles Include="$(ContentmentBundleSourcePath)/**/*.*" />
+    </ItemGroup>
+    <Message Importance="High" Text="Copying @(ContentmentBundleFiles-&gt;Count()) Contentment bundle files from '$(ContentmentBundleSourcePath)' to '$(ContentmentBundleDestinationPath)'" />
+    <MakeDir Directories="$(ContentmentBundleDestinationPath)" Condition="!Exists('$(ContentmentBundleDestinationPath)')" />
+    <Copy SourceFiles="@(ContentmentBundleFiles)" DestinationFiles="@(ContentmentBundleFiles->'$(ContentmentBundleDestinationPath)\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
+  </Target>
+```
+
+Additionally the bundle should be imported in your test setup.  
+For example in `setup.ts` when using Vitest.
+
+```typescript
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+
+const bundle = path.resolve(__dirname, './vendor/contentment/index.js');
+if (fs.existsSync(bundle)) {
+  const bundleHref = pathToFileURL(bundle).href;
+  await import(bundleHref).catch((e) => { console.error('Failed to import Contentment bundle.', e)});
+}
+```

--- a/src/Umbraco.Community.Contentment.Client/.gitignore
+++ b/src/Umbraco.Community.Contentment.Client/.gitignore
@@ -23,3 +23,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+/tsdoc-metadata.json
+/dist/
+/temp/

--- a/src/Umbraco.Community.Contentment.Client/api-extractor.json
+++ b/src/Umbraco.Community.Contentment.Client/api-extractor.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+  "projectFolder": ".",
+  "mainEntryPointFilePath": "./dist/types/api-aggregator.d.ts",
+  "compiler": {
+    "tsconfigFilePath": "./tsconfig.api.json"
+  },
+  "dtsRollup": {
+    "enabled": true,
+    "untrimmedFilePath": "./dist/index.d.ts"
+  },
+  "messages": {
+    "compilerMessageReporting": { "default": { "logLevel": "warning" } }
+  },
+	"apiReport": {
+		"enabled": true,
+		"reportFolder": "./dist"
+	},
+	"docModel": {
+		"enabled": true
+	}
+}

--- a/src/Umbraco.Community.Contentment.Client/package-lock.json
+++ b/src/Umbraco.Community.Contentment.Client/package-lock.json
@@ -14,6 +14,7 @@
 			"devDependencies": {
 				"@hey-api/client-fetch": "^0.10.0",
 				"@hey-api/openapi-ts": "^0.66.6",
+				"@microsoft/api-extractor": "^7.55.2",
 				"@types/sortablejs": "^1.15.8",
 				"typescript": "5.9.3",
 				"vite": "^7.1.11"
@@ -503,6 +504,29 @@
 				"typescript": "^5.5.3"
 			}
 		},
+		"node_modules/@isaacs/balanced-match": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+			"integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/@isaacs/brace-expansion": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+			"integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@isaacs/balanced-match": "^4.0.1"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
 		"node_modules/@jsdevtools/ono": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
@@ -522,6 +546,88 @@
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@lit-labs/ssr-dom-shim": "^1.2.0"
+			}
+		},
+		"node_modules/@microsoft/api-extractor": {
+			"version": "7.55.2",
+			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.55.2.tgz",
+			"integrity": "sha512-1jlWO4qmgqYoVUcyh+oXYRztZde/pAi7cSVzBz/rc+S7CoVzDasy8QE13dx6sLG4VRo8SfkkLbFORR6tBw4uGQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@microsoft/api-extractor-model": "7.32.2",
+				"@microsoft/tsdoc": "~0.16.0",
+				"@microsoft/tsdoc-config": "~0.18.0",
+				"@rushstack/node-core-library": "5.19.1",
+				"@rushstack/rig-package": "0.6.0",
+				"@rushstack/terminal": "0.19.5",
+				"@rushstack/ts-command-line": "5.1.5",
+				"diff": "~8.0.2",
+				"lodash": "~4.17.15",
+				"minimatch": "10.0.3",
+				"resolve": "~1.22.1",
+				"semver": "~7.5.4",
+				"source-map": "~0.6.1",
+				"typescript": "5.8.2"
+			},
+			"bin": {
+				"api-extractor": "bin/api-extractor"
+			}
+		},
+		"node_modules/@microsoft/api-extractor-model": {
+			"version": "7.32.2",
+			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.32.2.tgz",
+			"integrity": "sha512-Ussc25rAalc+4JJs9HNQE7TuO9y6jpYQX9nWD1DhqUzYPBr3Lr7O9intf+ZY8kD5HnIqeIRJX7ccCT0QyBy2Ww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@microsoft/tsdoc": "~0.16.0",
+				"@microsoft/tsdoc-config": "~0.18.0",
+				"@rushstack/node-core-library": "5.19.1"
+			}
+		},
+		"node_modules/@microsoft/api-extractor/node_modules/diff": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+			"integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/@microsoft/api-extractor/node_modules/typescript": {
+			"version": "5.8.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+			"integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/@microsoft/tsdoc": {
+			"version": "0.16.0",
+			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+			"integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@microsoft/tsdoc-config": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.18.0.tgz",
+			"integrity": "sha512-8N/vClYyfOH+l4fLkkr9+myAoR6M7akc8ntBJ4DJdWH2b09uVfr71+LTMpNyG19fNqWDg8KEDZhx5wxuqHyGjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@microsoft/tsdoc": "0.16.0",
+				"ajv": "~8.12.0",
+				"jju": "~1.4.0",
+				"resolve": "~1.22.2"
 			}
 		},
 		"node_modules/@remirror/core-constants": {
@@ -837,6 +943,117 @@
 			"os": [
 				"win32"
 			]
+		},
+		"node_modules/@rushstack/node-core-library": {
+			"version": "5.19.1",
+			"resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.19.1.tgz",
+			"integrity": "sha512-ESpb2Tajlatgbmzzukg6zyAhH+sICqJR2CNXNhXcEbz6UGCQfrKCtkxOpJTftWc8RGouroHG0Nud1SJAszvpmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "~8.13.0",
+				"ajv-draft-04": "~1.0.0",
+				"ajv-formats": "~3.0.1",
+				"fs-extra": "~11.3.0",
+				"import-lazy": "~4.0.0",
+				"jju": "~1.4.0",
+				"resolve": "~1.22.1",
+				"semver": "~7.5.4"
+			},
+			"peerDependencies": {
+				"@types/node": "*"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@rushstack/node-core-library/node_modules/ajv": {
+			"version": "8.13.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+			"integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.4.1"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@rushstack/problem-matcher": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@rushstack/problem-matcher/-/problem-matcher-0.1.1.tgz",
+			"integrity": "sha512-Fm5XtS7+G8HLcJHCWpES5VmeMyjAKaWeyZU5qPzZC+22mPlJzAsOxymHiWIfuirtPckX3aptWws+K2d0BzniJA==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/node": "*"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@rushstack/rig-package": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.6.0.tgz",
+			"integrity": "sha512-ZQmfzsLE2+Y91GF15c65L/slMRVhF6Hycq04D4TwtdGaUAbIXXg9c5pKA5KFU7M4QMaihoobp9JJYpYcaY3zOw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"resolve": "~1.22.1",
+				"strip-json-comments": "~3.1.1"
+			}
+		},
+		"node_modules/@rushstack/terminal": {
+			"version": "0.19.5",
+			"resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.19.5.tgz",
+			"integrity": "sha512-6k5tpdB88G0K7QrH/3yfKO84HK9ggftfUZ51p7fePyCE7+RLLHkWZbID9OFWbXuna+eeCFE7AkKnRMHMxNbz7Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@rushstack/node-core-library": "5.19.1",
+				"@rushstack/problem-matcher": "0.1.1",
+				"supports-color": "~8.1.1"
+			},
+			"peerDependencies": {
+				"@types/node": "*"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@rushstack/ts-command-line": {
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.1.5.tgz",
+			"integrity": "sha512-YmrFTFUdHXblYSa+Xc9OO9FsL/XFcckZy0ycQ6q7VSBsVs5P0uD9vcges5Q9vctGlVdu27w+Ct6IuJ458V0cTQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@rushstack/terminal": "0.19.5",
+				"@types/argparse": "1.0.38",
+				"argparse": "~1.0.9",
+				"string-argv": "~0.3.1"
+			}
+		},
+		"node_modules/@rushstack/ts-command-line/node_modules/argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
 		},
 		"node_modules/@tiptap/core": {
 			"version": "2.11.7",
@@ -1343,6 +1560,13 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
 			}
+		},
+		"node_modules/@types/argparse": {
+			"version": "1.0.38",
+			"resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
+			"integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/diff": {
 			"version": "7.0.2",
@@ -2358,6 +2582,56 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/ajv": {
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-draft-04": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+			"integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"ajv": "^8.5.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2577,6 +2851,13 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/fdir": {
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2593,6 +2874,21 @@
 				"picomatch": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/fs-extra": {
+			"version": "11.3.3",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
+			"integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
 			}
 		},
 		"node_modules/fs-minipass": {
@@ -2634,6 +2930,16 @@
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/giget": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/giget/-/giget-1.2.5.tgz",
@@ -2658,6 +2964,13 @@
 			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
 			"license": "MIT"
 		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/handlebars": {
 			"version": "4.7.8",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
@@ -2679,6 +2992,55 @@
 				"uglify-js": "^3.1.4"
 			}
 		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/import-lazy": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+			"integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-core-module": {
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/jiti": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -2687,6 +3049,13 @@
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
 			}
+		},
+		"node_modules/jju": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+			"integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.1",
@@ -2698,6 +3067,26 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/jsonfile": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
 			}
 		},
 		"node_modules/linkify-it": {
@@ -2782,6 +3171,19 @@
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"license": "MIT"
 		},
+		"node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/markdown-it": {
 			"version": "14.1.0",
 			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
@@ -2817,6 +3219,22 @@
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
 			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
 			"license": "MIT"
+		},
+		"node_modules/minimatch": {
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+			"integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@isaacs/brace-expansion": "^5.0.0"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
 		},
 		"node_modules/minimist": {
 			"version": "1.2.8",
@@ -2965,6 +3383,13 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
 			"integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+			"license": "MIT"
+		},
+		"node_modules/path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/pathe": {
@@ -3244,6 +3669,16 @@
 				"prosemirror-transform": "^1.1.0"
 			}
 		},
+		"node_modules/punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/punycode.js": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
@@ -3274,6 +3709,37 @@
 			"funding": {
 				"type": "individual",
 				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/resolve": {
+			"version": "1.22.11",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+			"integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-core-module": "^2.16.1",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/rollup": {
@@ -3334,6 +3800,22 @@
 				"tslib": "^2.1.0"
 			}
 		},
+		"node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/sortablejs": {
 			"version": "1.15.6",
 			"resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.6.tgz",
@@ -3357,6 +3839,65 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/string-argv": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+			"integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6.19"
+			}
+		},
+		"node_modules/strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/tar": {
@@ -3442,6 +3983,26 @@
 			},
 			"engines": {
 				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"punycode": "^2.1.0"
 			}
 		},
 		"node_modules/uuid": {

--- a/src/Umbraco.Community.Contentment.Client/package.json
+++ b/src/Umbraco.Community.Contentment.Client/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "tsc && vite build --watch",
 		"build": "tsc && vite build",
-		"build:api": "tsc --project tsconfig.api.json",
+		"build:api": "tsc --project tsconfig.api.json && api-extractor run --local --verbose",
 		"generate:server-api": "openapi-ts --file openapi-ts.config.js"
 	},
 	"dependencies": {
@@ -19,6 +19,7 @@
 	"devDependencies": {
 		"@hey-api/client-fetch": "^0.10.0",
 		"@hey-api/openapi-ts": "^0.66.6",
+		"@microsoft/api-extractor": "^7.55.2",
 		"@types/sortablejs": "^1.15.8",
 		"typescript": "5.9.3",
 		"vite": "^7.1.11"

--- a/src/Umbraco.Community.Contentment.Client/src/api-aggregator.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/api-aggregator.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './index';

--- a/src/Umbraco.Community.Contentment.Client/src/global-context/manifests.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/global-context/manifests.ts
@@ -3,4 +3,4 @@
 
 import { manifests as liquid } from './liquid/manifests.js';
 
-export const manifests = [...liquid];
+export const manifests: Array<UmbExtensionManifest> = [...liquid];

--- a/src/Umbraco.Community.Contentment.Client/tsconfig.api.json
+++ b/src/Umbraco.Community.Contentment.Client/tsconfig.api.json
@@ -1,7 +1,7 @@
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
-		"outDir": "./types",
+		"outDir": "./dist/types",
 		"rootDir": "./src",
 		"declaration": true,
 		"declarationMap": true,

--- a/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
+++ b/src/Umbraco.Community.Contentment/Umbraco.Community.Contentment.csproj
@@ -14,7 +14,7 @@
         <Product>Umbraco.Community.Contentment</Product>
         <Title>Contentment for Umbraco</Title>
         <Description>Contentment, a collection of components for Umbraco.</Description>
-        <Version>6.1.0</Version>
+        <Version>6.1.1-alpha003</Version>
         <Authors>Lee Kelleher</Authors>
         <Company>Lee Kelleher</Company>
         <Copyright>$([System.DateTime]::Now.Year) © $(Company)</Copyright>
@@ -68,4 +68,20 @@
         <None Remove="wwwroot\**" />
     </ItemGroup>
 
+    <Target Name="Contentment_BuildTypes" BeforeTargets="GenerateNuspec">
+        <Exec Command="npm run build:api" WorkingDirectory="..\Umbraco.Community.Contentment.Client" />
+    </Target>
+
+    <ItemGroup>
+        <None Include="..\Umbraco.Community.Contentment.Client\dist\index.d.ts">
+            <Pack>true</Pack>
+            <PackagePath>contentFiles\any\any\vendor\Contentment\</PackagePath>
+            <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+        </None>
+        <None Include=".\build\Umbraco.Community.Contentment.targets">
+            <Pack>true</Pack>
+            <PackagePath>buildTransitive\</PackagePath>
+            <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
 </Project>

--- a/src/Umbraco.Community.Contentment/build/Umbraco.Community.Contentment.targets
+++ b/src/Umbraco.Community.Contentment/build/Umbraco.Community.Contentment.targets
@@ -1,0 +1,18 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- TODO: Just here for informational purposes. Consumers can set to false to avoid. Maybe flip so consumers need to turn on? -->
+    <Contentment_CopyTypes>true</Contentment_CopyTypes>
+
+    <_ContentmentTypesInPackage>$(MSBuildThisFileDirectory)..\contentFiles\any\any\vendor\Contentment\index.d.ts</_ContentmentTypesInPackage>
+    <_ContentmentVendorFolder>$(MSBuildProjectDirectory)\vendor\Contentment</_ContentmentVendorFolder>
+  </PropertyGroup>
+
+  <Target Name="Contentment_CopyTypesToVendorFolder"
+          AfterTargets="PrepareForBuild"
+          Condition=" Exists('$(_ContentmentTypesInPackage)') and '$(Contentment_CopyTypes)' != 'false' ">
+    <MakeDir Directories="$(_ContentmentVendorFolder)" Condition="!Exists('$(_ContentmentVendorFolder)')" />
+    <Copy SourceFiles="$(_ContentmentTypesInPackage)"
+          DestinationFolder="$(_ContentmentVendorFolder)"
+          SkipUnchangedFiles="true" />
+  </Target>
+</Project>


### PR DESCRIPTION
### Description

Adds npm script and msbuild tasks to generate and include a type definition file for TypeScript.  
The file is copied to /vendor/Contentment in the project it's installed to. (Transitive)
We should discuss whether it should be opt-in or opt-out, and whether the built js should also be copied.

TBH, I just finished what you started in tsconfig.api.json. 🤓👌

### Related Issues?

Satisfies the request in discussion #520.

### Types of changes

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

I noticed that package.lock.json has a few added packages in it in my commit.  
Dunno if it's just patches, new dependencies or what, but I recon the latter and that they are transitive deps from @microsoft/api-extractor.

### Checklist

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.

### Things to consider and/or address before merging and/or releasing

- The index.d.ts file is now _uncritically_ copied to any project installing the package.
  - It can be opted out by setting the msbuild property `Contentment_CopyTypes` to false
  - Should likely be the other way around so people can _opt in_ instead, but then it needs clear and discoverable docs. :)
- In order to use Contentment from tests, we need the actual bundled JS as well.
  - Could add another target that copies all the JS files into the same vendor folder.
  - Should definitely be _opt in_ via a second property, eg. `Contentment_CopyJsBundle`.
- The added "typescript.md" file should be updated to reflect decisions about the above mechanisms. :)
