### PR TITLE
GetCurrentContent missing search in membertype

### DIFF
--- a/src/Umbraco.Community.Contentment/Services/ContentmentContentContext.cs
+++ b/src/Umbraco.Community.Contentment/Services/ContentmentContentContext.cs
@@ -4,7 +4,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Extensions;
 
@@ -15,15 +19,21 @@ namespace Umbraco.Community.Contentment.Services
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IUmbracoContextAccessor _umbracoContextAccessor;
         private readonly IVariationContextAccessor _variationContextAccessor;
+        private readonly IIdKeyMap _idKeyMap;
+        private readonly IServiceProvider _serviceProvider;
 
         public ContentmentContentContext(
             IHttpContextAccessor httpContextAccessor,
             IUmbracoContextAccessor umbracoContextAccessor,
-            IVariationContextAccessor variationContextAccessor)
+            IVariationContextAccessor variationContextAccessor,
+            IIdKeyMap idKeyMap,
+            IServiceProvider serviceProvider)
         {
             _httpContextAccessor = httpContextAccessor;
             _umbracoContextAccessor = umbracoContextAccessor;
             _variationContextAccessor = variationContextAccessor;
+            _idKeyMap = idKeyMap;
+            _serviceProvider = serviceProvider;
         }
 
         public T? GetCurrentContentId<T>(out bool isParent)
@@ -76,7 +86,26 @@ namespace Umbraco.Community.Contentment.Services
                 if (currentContentKey.HasValue == true)
                 {
                     SetVariationContext();
-                    return umbracoContext.Content?.GetById(true, currentContentKey.Value);
+
+                    var content = umbracoContext.Content?.GetById(true, currentContentKey.Value);
+
+                    // NOTE: Check if the content is a member.
+                    if (content is null)
+                    {
+                        var memberKeyAttempt = _idKeyMap.GetIdForKey(currentContentKey.Value, UmbracoObjectTypes.Member);
+                        if (memberKeyAttempt.Success)
+                        {
+                            using var scope = _serviceProvider.CreateScope();
+                            var memberManager = scope.ServiceProvider.GetRequiredService<IMemberManager>();
+
+                            var memberId = memberKeyAttempt.Result;
+                            var member = memberManager.FindByIdAsync(memberId.ToString()).Result;
+                            if (member is not null)
+                            {
+                                content = memberManager.AsPublishedMember(member);
+                            }
+                        }
+                    }
                 }
             }
 

--- a/src/Umbraco.Community.Contentment/Services/ContentmentContentContext.cs
+++ b/src/Umbraco.Community.Contentment/Services/ContentmentContentContext.cs
@@ -106,6 +106,7 @@ namespace Umbraco.Community.Contentment.Services
                             }
                         }
                     }
+                    return content;
                 }
             }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

### Description
Disclaimer:
This is my first push to umbraco contentment and it might not be up to standards. I would appreciate any help or suggentions to improve the logic. 

I've added an extra check for UmbracoObjectTypes.Member content.

Improvements:
Maybe we need to add more types to find the ipublishedcontent like "UmbracoObjectTypes.Media"

<!-- Please include a summary of the change and which issue is fixed.
     Please also include relevant motivation and context.
     List any dependencies that are required for this change. -->

### Related Issues?

<!-- If suggesting a new feature or change, please discuss it in an issue first.
     If fixing a bug for an existing issue, please link to the issue here: -->

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
     Please do not upgrade any NuGet dependencies.
     Please do not modify any licensing information, e.g. do not update the copyright year. -->

- [ ] Documentation change
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
