### PR TITLE
TypeScript definitions: Publish as npm package

### DIFF
--- a/.claude/rules/client.md
+++ b/.claude/rules/client.md
@@ -30,9 +30,10 @@ Scoped to `src/Umbraco.Community.Contentment.Client/` — the TypeScript/Lit Umb
 
 ## Entry points and build
 
-- `src/index.ts` — public API re-exports (components, utilities).
+- `src/index.ts` — public API re-exports (components, utilities, aggregated types).
 - `src/manifests.ts` — aggregated extension manifests from every subtree.
 - Vite builds both as ESM with `formats: ['es']`, externalising `@umbraco/*`. Output goes to `../Umbraco.Community.Contentment/wwwroot/App_Plugins/Contentment/` so it ships inside the NuGet package as a static web asset.
+- `npm run generate:types` — emits TypeScript declarations (`.d.ts` + `.d.ts.map`) into `dist/` via `tsconfig.types.json`. Also chained at the end of `npm run build`. The `dist/` output is published to GitHub Packages as `@leekelleher/umbraco-contentment` on release.
 
 ## Extension types in use
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,6 @@ jobs:
     - run: npm run build
       working-directory: src/Umbraco.Community.Contentment.Client
 
-    - name: Build TypeScript declarations
-      run: npm run build:api
-      working-directory: src/Umbraco.Community.Contentment.Client
-
     - name: Set npm package version from tag
       run: npm pkg set version=${{github.ref_name}}
       working-directory: src/Umbraco.Community.Contentment.Client

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,26 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version-file: src/Umbraco.Community.Contentment.Client/.nvmrc
+        registry-url: 'https://npm.pkg.github.com'
+        scope: '@leekelleher'
     - run: npm i
       working-directory: src/Umbraco.Community.Contentment.Client
     - run: npm run build
       working-directory: src/Umbraco.Community.Contentment.Client
+
+    - name: Build TypeScript declarations
+      run: npm run build:api
+      working-directory: src/Umbraco.Community.Contentment.Client
+
+    - name: Set npm package version from tag
+      run: npm pkg set version=${{github.ref_name}}
+      working-directory: src/Umbraco.Community.Contentment.Client
+
+    - name: Push to GitHub npm
+      run: npm publish
+      working-directory: src/Umbraco.Community.Contentment.Client
+      env:
+        NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,7 @@ Run from the repo root unless noted.
 cd src/Umbraco.Community.Contentment.Client
 npm install
 npm run dev                  # tsc + vite build --watch (active development)
-npm run build                # tsc + vite build (production)
-npm run build:api            # build API types only (uses tsconfig.api.json)
+npm run build                # tsc + vite build + tsc types (production package + .d.ts)
 ```
 
 Node >= 22 (pinned in `.nvmrc`). The build writes directly into `../Umbraco.Community.Contentment/wwwroot/App_Plugins/Contentment/`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,3 +46,8 @@ Information about Contentment's [telemetry feature](../docs/telemetry.md).
 #### Tree Dashboard
 
 Information about Contentment's [tree dashboard](../docs/tree-dashboard.md).
+
+#### TypeScript
+
+Information about [referencing Contentment TypeScript types in your own implementations](../docs/typescript.md).
+

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -1,0 +1,54 @@
+<img src="assets/img/logo.png" alt="Contentment for Umbraco logo" title="A state of Umbraco happiness." height="130" align="right">
+
+## Contentment for Umbraco
+
+### TypeScript
+
+Contentment publishes its TypeScript definitions to the [GitHub Packages](https://github.com/leekelleher?tab=packages) npm registry as `@leekelleher/umbraco-contentment`.
+
+> **This package currently ships TypeScript types only.**
+> The runtime (JavaScript) continues to ship inside the `Umbraco.Community.Contentment` NuGet package as a static web asset (`App_Plugins/Contentment/*`) — Umbraco loads it at runtime.
+> The npm package exists purely so consumer projects can get autocomplete and compile-time checking when extending Contentment's client side (e.g. implementing a custom `ContentmentDataSourceApi`).
+
+#### Installation
+
+The package is hosted on GitHub's npm registry, so your project needs an `.npmrc` file to tell npm where to resolve the `@leekelleher` scope, and a GitHub Personal Access Token with the `read:packages` scope.
+
+Create (or append to) `.npmrc` in your project root:
+
+```ini
+@leekelleher:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+```
+
+Set the `GITHUB_TOKEN` environment variable to a [Personal Access Token (classic)](https://github.com/settings/tokens) with the `read:packages` scope.
+
+Then install the package as a dev dependency:
+
+```bash
+npm install --save-dev @leekelleher/umbraco-contentment
+```
+
+#### Usage
+
+Import the types you need in your own extension code:
+
+```ts
+import type { ContentmentDataSourceApi, ContentmentDataSourceItem } from '@leekelleher/umbraco-contentment';
+
+export class MyCustomDataSource implements ContentmentDataSourceApi {
+  async getItems(): Promise<Array<ContentmentDataSourceItem>> {
+    // ...
+  }
+}
+```
+
+Because declaration maps are shipped alongside the types, "Go to Definition" in VS Code will jump to Contentment's source TypeScript — useful when exploring the available APIs.
+
+#### Versioning
+
+The npm package version tracks the NuGet package version one-to-one. Pick the npm version that matches the `Umbraco.Community.Contentment` NuGet package installed in your Umbraco site, so the types reflect the runtime you actually have.
+
+#### Further reading
+
+- [GitHub Packages — Working with the npm registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-to-github-packages)

--- a/src/Umbraco.Community.Contentment.Client/package.json
+++ b/src/Umbraco.Community.Contentment.Client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@leekelleher/umbraco-contentment",
-	"version": "6.2.0",
+	"version": "6.1.2",
 	"description": "TypeScript definitions for Contentment, a collection of components for Umbraco.",
 	"author": "Lee Kelleher",
 	"license": "MIT",
@@ -29,8 +29,8 @@
 	},
 	"scripts": {
 		"dev": "tsc && vite build --watch",
-		"build": "tsc && vite build",
-		"build:api": "tsc --project tsconfig.api.json",
+		"build": "tsc && vite build && tsc --project tsconfig.types.json",
+		"generate:types": "tsc --project tsconfig.types.json",
 		"generate:server-api": "openapi-ts --file openapi-ts.config.js"
 	},
 	"dependencies": {

--- a/src/Umbraco.Community.Contentment.Client/package.json
+++ b/src/Umbraco.Community.Contentment.Client/package.json
@@ -1,8 +1,32 @@
 {
-	"name": "umbraco-contentment",
-	"private": true,
+	"name": "@leekelleher/umbraco-contentment",
 	"version": "6.2.0",
+	"description": "TypeScript definitions for Contentment, a collection of components for Umbraco.",
+	"author": "Lee Kelleher",
+	"license": "MIT",
+	"homepage": "https://github.com/leekelleher/umbraco-contentment",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/leekelleher/umbraco-contentment.git"
+	},
+	"bugs": {
+		"url": "https://github.com/leekelleher/umbraco-contentment/issues"
+	},
 	"type": "module",
+	"main": "./dist/index.d.ts",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts"
+		},
+		"./package.json": "./package.json"
+	},
+	"files": [
+		"dist/"
+	],
+	"publishConfig": {
+		"registry": "https://npm.pkg.github.com"
+	},
 	"scripts": {
 		"dev": "tsc && vite build --watch",
 		"build": "tsc && vite build",

--- a/src/Umbraco.Community.Contentment.Client/src/global-context/manifests.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/global-context/manifests.ts
@@ -3,4 +3,4 @@
 
 import { manifests as liquid } from './liquid/manifests.js';
 
-export const manifests = [...liquid];
+export const manifests: Array<UmbExtensionManifest> = [...liquid];

--- a/src/Umbraco.Community.Contentment.Client/src/index.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/index.ts
@@ -4,3 +4,4 @@
 export * from './api/index.js';
 export * from './components/index.js';
 export * from './utils/index.js';
+export type * from './types.js';

--- a/src/Umbraco.Community.Contentment.Client/tsconfig.api.json
+++ b/src/Umbraco.Community.Contentment.Client/tsconfig.api.json
@@ -1,7 +1,7 @@
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
-		"outDir": "./types",
+		"outDir": "./dist",
 		"rootDir": "./src",
 		"declaration": true,
 		"declarationMap": true,

--- a/src/Umbraco.Community.Contentment.Client/tsconfig.types.json
+++ b/src/Umbraco.Community.Contentment.Client/tsconfig.types.json
@@ -6,7 +6,6 @@
 		"declaration": true,
 		"declarationMap": true,
 		"emitDeclarationOnly": true,
-		"noEmit": false,
-		"sourceMap": false
+		"noEmit": false
 	}
 }


### PR DESCRIPTION
## Summary

Publishes Contentment's TypeScript type definitions as an npm package — `@leekelleher/umbraco-contentment` — to the GitHub Packages npm registry. Consumers can now install the package to get IntelliSense and compile-time checking when extending Contentment's client side (e.g. implementing a custom `ContentmentDataSourceApi`).

## Background

Prompted by [Discussion #520](https://github.com/leekelleher/umbraco-contentment/discussions/520), where @lars-erik raised the need for publishable TypeScript types. Lars followed up with [PR #521](https://github.com/leekelleher/umbraco-contentment/pull/521), a working implementation that ships the types inside the NuGet package via MSBuild content files. His prototyping and the in-depth discussion there — npm vs NuGet, opt-in vs opt-out, how test scenarios should work — were instrumental in shaping the approach taken here. Huge thanks, Lars! 🙌

This PR takes an alternative distribution path (npm over NuGet), motivated by the expectation that TypeScript consumers reach for `npm install` first, and that per-project MSBuild auto-copy is heavier machinery than a types file warrants.

## What ships

- **Scope:** TypeScript declarations (`.d.ts` + `.d.ts.map`) only, generated by plain `tsc --emitDeclarationOnly`. Per-file output with declaration maps, so "Go to Definition" in consumer IDEs lands on the actual source TypeScript. The runtime continues to ship through the existing NuGet package as an Umbraco static web asset (`App_Plugins/Contentment/*`).
- **Name:** `@leekelleher/umbraco-contentment` — mirrors the NuGet package name, leaving room to grow (e.g. adding runtime JS for test scenarios) without a rename.
- **Distribution:** GitHub Packages npm registry (`https://npm.pkg.github.com/leekelleher`). Reuses the `GITHUB_TOKEN` the release workflow already uses for NuGet — no new secrets.
- **Lifecycle:** versioned and published in the existing `release.yml` workflow on every SemVer tag (including pre-releases), in lockstep with the NuGet package.
