### PR TITLE
.NET Languages: adds displayMode config option

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/LanguagesDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/LanguagesDataListSource.cs
@@ -66,6 +66,8 @@ namespace Umbraco.Community.Contentment.DataEditors
 
             return GetCultures()
                 .Select(x => (Culture: x, Name: GetDisplayName(x, displayMode)))
+                // Sort by the server's CurrentCulture, not the backoffice user's language.
+                // Close enough for an alphabetical list; a perfect per-user sort isn't worth the extra overhead.
                 .OrderBy(x => x.Name, StringComparer.CurrentCultureIgnoreCase)
                 .Select(x => ToDataListItem(x.Culture, x.Name));
         }
@@ -162,6 +164,10 @@ namespace Umbraco.Community.Contentment.DataEditors
             {
                 var userCulture = CultureInfo.GetCultureInfo(userLanguage);
                 var previous = CultureInfo.CurrentUICulture;
+                // CultureInfo has no "GetDisplayName(inCulture)" API; temporarily switching
+                // CurrentUICulture is the standard .NET pattern to obtain a localised name.
+                // The try/finally restores the original value. Safe here because GetItems is
+                // synchronous — no await suspension points while the culture is mutated.
                 try
                 {
                     CultureInfo.CurrentUICulture = userCulture;

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/LanguagesDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/LanguagesDataListSource.cs
@@ -13,9 +13,9 @@ namespace Umbraco.Community.Contentment.DataEditors
 {
     public sealed class LanguagesDataListSource : IContentmentDataSource, IDataPickerSource
     {
-        private const string _displayModeEnglishName = "englishName";
-        private const string _displayModeNativeName = "nativeName";
-        private const string _displayModeBackofficeUserLanguage = "backofficeUserLanguage";
+        private const string _labelStyleEnglishName = "english";
+        private const string _labelStyleNativeName = "native";
+        private const string _labelStyleBackofficeUserLanguage = "backoffice";
 
         private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
 
@@ -36,17 +36,32 @@ namespace Umbraco.Community.Contentment.DataEditors
         {
             new ContentmentConfigurationField
             {
-                Key = "displayMode",
-                Name = "Display mode",
-                Description = "Choose how each language name is displayed in the list.",
+                Key = "labelStyle",
+                Name = "Label style",
+                Description = "Choose how each language name is displayed.",
                 PropertyEditorUiAlias = RadioButtonListDataListEditor.DataEditorUiAlias,
                 Config = new Dictionary<string, object>
                 {
                     { Constants.Conventions.ConfigurationFieldAliases.Items, new[]
                         {
-                            new DataListItem { Name = "English name", Value = _displayModeEnglishName, Description = "e.g. \"German\", \"Japanese\"." },
-                            new DataListItem { Name = "Native name", Value = _displayModeNativeName, Description = "Each language in its own language, e.g. \"Deutsch\", \"日本語\"." },
-                            new DataListItem { Name = "Backoffice user language", Value = _displayModeBackofficeUserLanguage, Description = "Localised in the current backoffice user's language, e.g. \"allemand\", \"japonais\" for a French user." },
+                            new DataListItem
+                            {
+                                Name = "English name",
+                                Value = _labelStyleEnglishName,
+                                Description = "e.g. \"German\", \"Japanese\"."
+                            },
+                            new DataListItem
+                            {
+                                Name = "Native name",
+                                Value = _labelStyleNativeName,
+                                Description = "Each language in its own language, e.g. \"Deutsch\", \"日本語\"."
+                            },
+                            new DataListItem
+                            {
+                                Name = "Current backoffice user language",
+                                Value = _labelStyleBackofficeUserLanguage,
+                                Description = "Localized in the current backoffice user's language, e.g. \"allemand\", \"japonais\" for a French user."
+                            },
                         }
                     },
                 }
@@ -55,17 +70,17 @@ namespace Umbraco.Community.Contentment.DataEditors
 
         public Dictionary<string, object>? DefaultValues => new()
         {
-            { "displayMode", _displayModeEnglishName },
+            { "labelStyle", _labelStyleEnglishName },
         };
 
         public OverlaySize OverlaySize => OverlaySize.Small;
 
         public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
-            var displayMode = GetDisplayMode(config);
+            var labelStyle = GetLabelStyle(config);
 
             return GetCultures()
-                .Select(x => (Culture: x, Name: GetDisplayName(x, displayMode)))
+                .Select(x => (Culture: x, Name: GetDisplayName(x, labelStyle)))
                 // Sort by the server's CurrentCulture, not the backoffice user's language.
                 // Close enough for an alphabetical list; a perfect per-user sort isn't worth the extra overhead.
                 .OrderBy(x => x.Name, StringComparer.CurrentCultureIgnoreCase)
@@ -76,13 +91,13 @@ namespace Umbraco.Community.Contentment.DataEditors
         {
             if (values?.Any() == true)
             {
-                var displayMode = GetDisplayMode(config);
+                var labelStyle = GetLabelStyle(config);
                 var lookup = GetCultures().ToLookup(x => x.TwoLetterISOLanguageName, StringComparer.InvariantCultureIgnoreCase);
 
                 return Task.FromResult(values
                     .Where(x => lookup.Contains(x) == true)
                     .SelectMany(x => lookup[x])
-                    .Select(x => ToDataListItem(x, GetDisplayName(x, displayMode))));
+                    .Select(x => ToDataListItem(x, GetDisplayName(x, labelStyle))));
             }
 
             return Task.FromResult(Enumerable.Empty<DataListItem>());
@@ -98,10 +113,10 @@ namespace Umbraco.Community.Contentment.DataEditors
             }
             else
             {
-                var displayMode = GetDisplayMode(config);
+                var labelStyle = GetLabelStyle(config);
 
                 items = GetCultures()
-                    .Select(x => (Culture: x, Name: GetDisplayName(x, displayMode)))
+                    .Select(x => (Culture: x, Name: GetDisplayName(x, labelStyle)))
                     .Where(x => x.Name.InvariantContains(query) == true
                         || x.Culture.EnglishName.InvariantContains(query) == true
                         || x.Culture.TwoLetterISOLanguageName.InvariantStartsWith(query) == true)
@@ -133,21 +148,13 @@ namespace Umbraco.Community.Contentment.DataEditors
                 .Where(x => x.TwoLetterISOLanguageName.Length == 2);
         }
 
-        private static string GetDisplayMode(Dictionary<string, object>? config)
-        {
-            if (config?.TryGetValueAs("displayMode", out string? displayMode) == true &&
-                string.IsNullOrWhiteSpace(displayMode) == false)
-            {
-                return displayMode;
-            }
+        private static string GetLabelStyle(Dictionary<string, object> config)
+            => config.GetValueAsString("labelStyle", _labelStyleEnglishName) ?? _labelStyleEnglishName;
 
-            return _displayModeEnglishName;
-        }
-
-        private string GetDisplayName(CultureInfo culture, string displayMode) => displayMode switch
+        private string GetDisplayName(CultureInfo culture, string labelStyle) => labelStyle switch
         {
-            _displayModeNativeName => culture.NativeName,
-            _displayModeBackofficeUserLanguage => GetBackofficeUserDisplayName(culture),
+            _labelStyleNativeName => culture.NativeName,
+            _labelStyleBackofficeUserLanguage => GetBackofficeUserDisplayName(culture),
             _ => culture.EnglishName,
         };
 
@@ -165,7 +172,7 @@ namespace Umbraco.Community.Contentment.DataEditors
                 var userCulture = CultureInfo.GetCultureInfo(userLanguage);
                 var previous = CultureInfo.CurrentUICulture;
                 // CultureInfo has no "GetDisplayName(inCulture)" API; temporarily switching
-                // CurrentUICulture is the standard .NET pattern to obtain a localised name.
+                // CurrentUICulture is the standard .NET pattern to obtain a localized name.
                 // The try/finally restores the original value. Safe here because GetItems is
                 // synchronous — no await suspension points while the culture is mutated.
                 try

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/LanguagesDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/LanguagesDataListSource.cs
@@ -6,12 +6,24 @@
 using System.Globalization;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Security;
 using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.DataEditors
 {
     public sealed class LanguagesDataListSource : IContentmentDataSource, IDataPickerSource
     {
+        private const string _displayModeEnglishName = "englishName";
+        private const string _displayModeNativeName = "nativeName";
+        private const string _displayModeBackofficeUserLanguage = "backofficeUserLanguage";
+
+        private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+
+        public LanguagesDataListSource(IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+        {
+            _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+        }
+
         public string Name => ".NET Languages (ISO 639-1)";
 
         public string Description => "All the languages available in the .NET Framework, (as installed on the web server).";
@@ -20,29 +32,56 @@ namespace Umbraco.Community.Contentment.DataEditors
 
         public string Group => Constants.Conventions.DataSourceGroups.DotNet;
 
-        public IEnumerable<ContentmentConfigurationField> Fields => Enumerable.Empty<ContentmentConfigurationField>();
+        public IEnumerable<ContentmentConfigurationField> Fields => new[]
+        {
+            new ContentmentConfigurationField
+            {
+                Key = "displayMode",
+                Name = "Display mode",
+                Description = "Choose how each language name is displayed in the list.",
+                PropertyEditorUiAlias = RadioButtonListDataListEditor.DataEditorUiAlias,
+                Config = new Dictionary<string, object>
+                {
+                    { DropdownListDataListEditor.AllowEmpty, false },
+                    { Constants.Conventions.ConfigurationFieldAliases.Items, new[]
+                        {
+                            new DataListItem { Name = "English name", Value = _displayModeEnglishName, Description = "e.g. \"German\", \"Japanese\"." },
+                            new DataListItem { Name = "Native name", Value = _displayModeNativeName, Description = "Each language in its own language, e.g. \"Deutsch\", \"日本語\"." },
+                            new DataListItem { Name = "Backoffice user language", Value = _displayModeBackofficeUserLanguage, Description = "Localised in the current backoffice user's language, e.g. \"allemand\", \"japonais\" for a French user." },
+                        }
+                    },
+                }
+            }
+        };
 
-        public Dictionary<string, object>? DefaultValues => default;
+        public Dictionary<string, object>? DefaultValues => new()
+        {
+            { "displayMode", _displayModeEnglishName },
+        };
 
         public OverlaySize OverlaySize => OverlaySize.Small;
 
         public IEnumerable<DataListItem> GetItems(Dictionary<string, object> config)
         {
+            var displayMode = GetDisplayMode(config);
+
             return GetCultures()
-                .OrderBy(x => x.EnglishName)
-                .Select(ToDataListItem);
+                .Select(x => (Culture: x, Name: GetDisplayName(x, displayMode)))
+                .OrderBy(x => x.Name, StringComparer.CurrentCultureIgnoreCase)
+                .Select(x => ToDataListItem(x.Culture, x.Name));
         }
 
         public Task<IEnumerable<DataListItem>> GetItemsAsync(Dictionary<string, object> config, IEnumerable<string> values)
         {
             if (values?.Any() == true)
             {
+                var displayMode = GetDisplayMode(config);
                 var lookup = GetCultures().ToLookup(x => x.TwoLetterISOLanguageName, StringComparer.InvariantCultureIgnoreCase);
 
                 return Task.FromResult(values
                     .Where(x => lookup.Contains(x) == true)
                     .SelectMany(x => lookup[x])
-                    .Select(ToDataListItem));
+                    .Select(x => ToDataListItem(x, GetDisplayName(x, displayMode))));
             }
 
             return Task.FromResult(Enumerable.Empty<DataListItem>());
@@ -58,10 +97,15 @@ namespace Umbraco.Community.Contentment.DataEditors
             }
             else
             {
+                var displayMode = GetDisplayMode(config);
+
                 items = GetCultures()
-                    .Where(x => x.EnglishName.InvariantContains(query) == true || x.TwoLetterISOLanguageName.InvariantStartsWith(query) == true)
-                    .OrderBy(x => x.EnglishName)
-                    .Select(ToDataListItem);
+                    .Select(x => (Culture: x, Name: GetDisplayName(x, displayMode)))
+                    .Where(x => x.Name.InvariantContains(query) == true
+                        || x.Culture.EnglishName.InvariantContains(query) == true
+                        || x.Culture.TwoLetterISOLanguageName.InvariantStartsWith(query) == true)
+                    .OrderBy(x => x.Name, StringComparer.CurrentCultureIgnoreCase)
+                    .Select(x => ToDataListItem(x.Culture, x.Name));
             }
 
             if (items?.Any() == true)
@@ -88,11 +132,66 @@ namespace Umbraco.Community.Contentment.DataEditors
                 .Where(x => x.TwoLetterISOLanguageName.Length == 2);
         }
 
-        private DataListItem ToDataListItem(CultureInfo culture)
+        private static string GetDisplayMode(Dictionary<string, object>? config)
+        {
+            if (config?.TryGetValueAs("displayMode", out string? displayMode) == true &&
+                string.IsNullOrWhiteSpace(displayMode) == false)
+            {
+                return displayMode;
+            }
+
+            return _displayModeEnglishName;
+        }
+
+        private string GetDisplayName(CultureInfo culture, string displayMode)
+        {
+            switch (displayMode)
+            {
+                case _displayModeNativeName:
+                    return culture.NativeName;
+
+                case _displayModeBackofficeUserLanguage:
+                    return GetBackofficeUserDisplayName(culture);
+
+                default:
+                    return culture.EnglishName;
+            }
+        }
+
+        private string GetBackofficeUserDisplayName(CultureInfo culture)
+        {
+            var userLanguage = _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser?.Language;
+
+            if (string.IsNullOrWhiteSpace(userLanguage) == true)
+            {
+                return culture.EnglishName;
+            }
+
+            try
+            {
+                var userCulture = CultureInfo.GetCultureInfo(userLanguage);
+                var previous = CultureInfo.CurrentUICulture;
+                try
+                {
+                    CultureInfo.CurrentUICulture = userCulture;
+                    return culture.DisplayName;
+                }
+                finally
+                {
+                    CultureInfo.CurrentUICulture = previous;
+                }
+            }
+            catch (CultureNotFoundException)
+            {
+                return culture.EnglishName;
+            }
+        }
+
+        private static DataListItem ToDataListItem(CultureInfo culture, string name)
         {
             return new DataListItem
             {
-                Name = culture.EnglishName,
+                Name = name,
                 Value = culture.TwoLetterISOLanguageName,
                 Icon = "icon-fa-language",
                 Description = culture.TwoLetterISOLanguageName,

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/LanguagesDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/LanguagesDataListSource.cs
@@ -142,20 +142,12 @@ namespace Umbraco.Community.Contentment.DataEditors
             return _displayModeEnglishName;
         }
 
-        private string GetDisplayName(CultureInfo culture, string displayMode)
+        private string GetDisplayName(CultureInfo culture, string displayMode) => displayMode switch
         {
-            switch (displayMode)
-            {
-                case _displayModeNativeName:
-                    return culture.NativeName;
-
-                case _displayModeBackofficeUserLanguage:
-                    return GetBackofficeUserDisplayName(culture);
-
-                default:
-                    return culture.EnglishName;
-            }
-        }
+            _displayModeNativeName => culture.NativeName,
+            _displayModeBackofficeUserLanguage => GetBackofficeUserDisplayName(culture),
+            _ => culture.EnglishName,
+        };
 
         private string GetBackofficeUserDisplayName(CultureInfo culture)
         {

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/LanguagesDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/LanguagesDataListSource.cs
@@ -42,7 +42,6 @@ namespace Umbraco.Community.Contentment.DataEditors
                 PropertyEditorUiAlias = RadioButtonListDataListEditor.DataEditorUiAlias,
                 Config = new Dictionary<string, object>
                 {
-                    { DropdownListDataListEditor.AllowEmpty, false },
                     { Constants.Conventions.ConfigurationFieldAliases.Items, new[]
                         {
                             new DataListItem { Name = "English name", Value = _displayModeEnglishName, Description = "e.g. \"German\", \"Japanese\"." },

--- a/src/_uSync/Shared/DataTypes/DataListDataSourceNETLanguages.config
+++ b/src/_uSync/Shared/DataTypes/DataListDataSourceNETLanguages.config
@@ -10,7 +10,9 @@
   "dataSource": [
     {
       "key": "Umbraco.Community.Contentment.DataEditors.LanguagesDataListSource, Umbraco.Community.Contentment",
-      "value": {}
+      "value": {
+        "labelStyle": "native"
+      }
     }
   ],
   "listEditor": [


### PR DESCRIPTION
### Description

Adds a "Display mode"* option to the ".NET Languages" data source, to choose how language names are shown

- English name _(default unchanged behaviour)_, e.g. "German"
- Native name, e.g. "Deutsch", "日本語"
- Backoffice user language, localised to the current user's culture, e.g. "allemand" for a French user

### Related Issues?
Discussion : #546 

### Types of changes

- [x] New feature _(non-breaking change which adds functionality)_

### Checklist

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
