### PR TITLE
Umbraco Content data source: filter child nodes by document type

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentDataListSource.cs
@@ -67,6 +67,13 @@ namespace Umbraco.Community.Contentment.DataEditors
             },
             new ContentmentConfigurationField
             {
+                Key = "documentType",
+                Name = "Document types",
+                Description = "Select one or more document types to filter the child nodes by. By default, all child nodes are returned regardless of their document type.",
+                PropertyEditorUiAlias = "Umb.PropertyEditorUi.DocumentTypePicker",
+            },
+            new ContentmentConfigurationField
+            {
                 Key = "imageAlias",
                 Name = "Image alias",
                 Description = $"When using the Cards display mode, you can set a thumbnail image by enter the property alias of the media picker. The default alias is '{DefaultImageAlias}'.",
@@ -91,7 +98,12 @@ namespace Umbraco.Community.Contentment.DataEditors
             if (start is not null)
             {
                 var imageAlias = config.GetValueAs("imageAlias", DefaultImageAlias) ?? DefaultImageAlias;
-                var items = start.Children()?.Select(x => ToDataListItem(x, imageAlias)) ?? Enumerable.Empty<DataListItem>();
+                var documentType = GetDocumentTypeFilter(config);
+
+                var children = start.Children() ?? Enumerable.Empty<IPublishedContent>();
+                children = FilterByDocumentType(children, documentType);
+
+                var items = children.Select(x => ToDataListItem(x, imageAlias));
 
                 if (config.TryGetValueAs("sortAlphabetically", out bool sortAlphabetically) == true && sortAlphabetically == true)
                 {
@@ -112,13 +124,17 @@ namespace Umbraco.Community.Contentment.DataEditors
             {
                 var preview = true;
                 var imageAlias = config.GetValueAs("imageAlias", DefaultImageAlias) ?? DefaultImageAlias;
+                var documentType = GetDocumentTypeFilter(config);
 
-                return Task.FromResult(values
+                var content = values
                     .Select(x => UdiParser.TryParse(x, out GuidUdi? udi) == true ? udi : null)
                     .WhereNotNull()
                     .Select(x => umbracoContext.Content.GetById(preview, x.Guid))
-                    .WhereNotNull()
-                    .Select(x => ToDataListItem(x, imageAlias)));
+                    .WhereNotNull();
+
+                content = FilterByDocumentType(content, documentType);
+
+                return Task.FromResult(content.Select(x => ToDataListItem(x, imageAlias)));
             }
 
             return Task.FromResult(Enumerable.Empty<DataListItem>());
@@ -132,6 +148,9 @@ namespace Umbraco.Community.Contentment.DataEditors
                 var items = string.IsNullOrWhiteSpace(query) == false
                     ? start.SearchChildren(query).Select(x => x.Content)
                     : start.Children();
+
+                var documentType = GetDocumentTypeFilter(config);
+                items = FilterByDocumentType(items, documentType);
 
                 if (items?.Any() == true)
                 {
@@ -220,6 +239,77 @@ namespace Umbraco.Community.Contentment.DataEditors
             }
 
             return default;
+        }
+
+        private ISet<string>? GetDocumentTypeFilter(Dictionary<string, object> config)
+        {
+            // The Document Type Picker stores its value as a JSON array of UDIs/keys.
+            // We resolve them to content type aliases so we can match against IPublishedContent.ContentType.Alias.
+            var value = config.GetValueAs("documentType", string.Empty);
+            if (string.IsNullOrWhiteSpace(value) == true)
+            {
+                return null;
+            }
+
+            IEnumerable<string> tokens;
+
+            if (value.DetectIsJson() == true)
+            {
+                tokens = _jsonSerializer.Deserialize<IEnumerable<string>>(value) ?? Enumerable.Empty<string>();
+            }
+            else
+            {
+                tokens = new[] { value };
+            }
+
+            var aliases = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var token in tokens)
+            {
+                if (string.IsNullOrWhiteSpace(token) == true)
+                {
+                    continue;
+                }
+
+                Guid? key = null;
+
+                if (UdiParser.TryParse(token, out GuidUdi? udi) == true && udi is not null)
+                {
+                    key = udi.Guid;
+                }
+                else if (Guid.TryParse(token, out var parsedKey) == true)
+                {
+                    key = parsedKey;
+                }
+
+                if (key.HasValue == false)
+                {
+                    continue;
+                }
+
+                var alias = _contentTypeService.Get(key.Value)?.Alias;
+                if (string.IsNullOrWhiteSpace(alias) == false)
+                {
+                    aliases.Add(alias);
+                }
+            }
+
+            return aliases.Count > 0 ? aliases : null;
+        }
+
+        private static IEnumerable<IPublishedContent> FilterByDocumentType(IEnumerable<IPublishedContent>? items, ISet<string>? documentTypeAliases)
+        {
+            if (items is null)
+            {
+                return Enumerable.Empty<IPublishedContent>();
+            }
+
+            if (documentTypeAliases is null || documentTypeAliases.Count == 0)
+            {
+                return items;
+            }
+
+            return items.Where(x => x.ContentType?.Alias is not null && documentTypeAliases.Contains(x.ContentType.Alias) == true);
         }
 
         private DataListItem ToDataListItem(IPublishedContent content, string imageAlias = DefaultImageAlias)

--- a/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentDataListSource.cs
+++ b/src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentDataListSource.cs
@@ -67,9 +67,9 @@ namespace Umbraco.Community.Contentment.DataEditors
             },
             new ContentmentConfigurationField
             {
-                Key = "documentType",
-                Name = "Document types",
-                Description = "Select one or more document types to filter the child nodes by. By default, all child nodes are returned regardless of their document type.",
+                Key = "documentTypes",
+                Name = "Document type filter",
+                Description = "Select one or more document types to filter the child nodes. By default, all child nodes are returned regardless of their document type.",
                 PropertyEditorUiAlias = "Umb.PropertyEditorUi.DocumentTypePicker",
             },
             new ContentmentConfigurationField
@@ -98,12 +98,11 @@ namespace Umbraco.Community.Contentment.DataEditors
             if (start is not null)
             {
                 var imageAlias = config.GetValueAs("imageAlias", DefaultImageAlias) ?? DefaultImageAlias;
-                var documentType = GetDocumentTypeFilter(config);
+                var documentTypeKeys = GetDocumentTypeFilter(config);
 
-                var children = start.Children() ?? Enumerable.Empty<IPublishedContent>();
-                children = FilterByDocumentType(children, documentType);
-
-                var items = children.Select(x => ToDataListItem(x, imageAlias));
+                var items = (start.Children() ?? Enumerable.Empty<IPublishedContent>())
+                    .Where(x => IsDocumentTypeMatch(x, documentTypeKeys))
+                    .Select(x => ToDataListItem(x, imageAlias));
 
                 if (config.TryGetValueAs("sortAlphabetically", out bool sortAlphabetically) == true && sortAlphabetically == true)
                 {
@@ -124,15 +123,14 @@ namespace Umbraco.Community.Contentment.DataEditors
             {
                 var preview = true;
                 var imageAlias = config.GetValueAs("imageAlias", DefaultImageAlias) ?? DefaultImageAlias;
-                var documentType = GetDocumentTypeFilter(config);
+                var documentTypeKeys = GetDocumentTypeFilter(config);
 
                 var content = values
                     .Select(x => UdiParser.TryParse(x, out GuidUdi? udi) == true ? udi : null)
                     .WhereNotNull()
                     .Select(x => umbracoContext.Content.GetById(preview, x.Guid))
-                    .WhereNotNull();
-
-                content = FilterByDocumentType(content, documentType);
+                    .WhereNotNull()
+                    .Where(x => IsDocumentTypeMatch(x, documentTypeKeys));
 
                 return Task.FromResult(content.Select(x => ToDataListItem(x, imageAlias)));
             }
@@ -145,12 +143,13 @@ namespace Umbraco.Community.Contentment.DataEditors
             var start = GetStartContent(config);
             if (start != null)
             {
+                var documentTypeKeys = GetDocumentTypeFilter(config);
+
                 var items = string.IsNullOrWhiteSpace(query) == false
                     ? start.SearchChildren(query).Select(x => x.Content)
                     : start.Children();
 
-                var documentType = GetDocumentTypeFilter(config);
-                items = FilterByDocumentType(items, documentType);
+                items = items?.Where(x => IsDocumentTypeMatch(x, documentTypeKeys));
 
                 if (items?.Any() == true)
                 {
@@ -241,76 +240,31 @@ namespace Umbraco.Community.Contentment.DataEditors
             return default;
         }
 
-        private ISet<string>? GetDocumentTypeFilter(Dictionary<string, object> config)
+        private IReadOnlyList<Guid>? GetDocumentTypeFilter(Dictionary<string, object> config)
         {
-            // The Document Type Picker stores its value as a JSON array of UDIs/keys.
-            // We resolve them to content type aliases so we can match against IPublishedContent.ContentType.Alias.
-            var value = config.GetValueAs("documentType", string.Empty);
+            // The Document Type Picker stores its value as a comma-separated string of GUIDs.
+            // We compare them directly against IPublishedContent.ContentType.Key.
+            var value = config.GetValueAs("documentTypes", string.Empty);
             if (string.IsNullOrWhiteSpace(value) == true)
             {
                 return null;
             }
 
-            IEnumerable<string> tokens;
+            var keys = new List<Guid>();
 
-            if (value.DetectIsJson() == true)
+            foreach (var token in value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
             {
-                tokens = _jsonSerializer.Deserialize<IEnumerable<string>>(value) ?? Enumerable.Empty<string>();
-            }
-            else
-            {
-                tokens = new[] { value };
-            }
-
-            var aliases = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var token in tokens)
-            {
-                if (string.IsNullOrWhiteSpace(token) == true)
+                if (Guid.TryParse(token, out var key) == true)
                 {
-                    continue;
-                }
-
-                Guid? key = null;
-
-                if (UdiParser.TryParse(token, out GuidUdi? udi) == true && udi is not null)
-                {
-                    key = udi.Guid;
-                }
-                else if (Guid.TryParse(token, out var parsedKey) == true)
-                {
-                    key = parsedKey;
-                }
-
-                if (key.HasValue == false)
-                {
-                    continue;
-                }
-
-                var alias = _contentTypeService.Get(key.Value)?.Alias;
-                if (string.IsNullOrWhiteSpace(alias) == false)
-                {
-                    aliases.Add(alias);
+                    keys.Add(key);
                 }
             }
 
-            return aliases.Count > 0 ? aliases : null;
+            return keys.Count > 0 ? keys : null;
         }
 
-        private static IEnumerable<IPublishedContent> FilterByDocumentType(IEnumerable<IPublishedContent>? items, ISet<string>? documentTypeAliases)
-        {
-            if (items is null)
-            {
-                return Enumerable.Empty<IPublishedContent>();
-            }
-
-            if (documentTypeAliases is null || documentTypeAliases.Count == 0)
-            {
-                return items;
-            }
-
-            return items.Where(x => x.ContentType?.Alias is not null && documentTypeAliases.Contains(x.ContentType.Alias) == true);
-        }
+        private static bool IsDocumentTypeMatch(IPublishedContent content, IReadOnlyList<Guid>? documentTypeKeys)
+            => documentTypeKeys is null || documentTypeKeys.Contains(content.ContentType.Key) == true;
 
         private DataListItem ToDataListItem(IPublishedContent content, string imageAlias = DefaultImageAlias)
         {

--- a/src/_uSync/Shared/DataTypes/DataListDataSourceUmbracoContent.config
+++ b/src/_uSync/Shared/DataTypes/DataListDataSourceUmbracoContent.config
@@ -15,7 +15,8 @@
           "originKey": "7a17e1d4-36c6-48b0-971d-d1f09f7ae610",
           "originAlias": "ByKey"
         },
-        "sortAlphabetically": false
+        "sortAlphabetically": false,
+        "documentTypes": "fb0af6c1-bf68-46e7-ab43-2ee1c8149629,d97d5da6-b96e-480c-99f1-b3c90dd04828"
       }
     }
   ],


### PR DESCRIPTION
Umbraco Content data source: filter child nodes by document type

### Description

Adds an optional **"Document types"** configuration field to the **Umbraco Content** data source.

- When one or more document types are selected, the returned nodes are filtered to only those types across all three paths, the list (`GetItems`), value resolution (`GetValue`), and search (`Search`).
- When no document types are selected, behaviour is unchanged: all child nodes are returned as before.
- Selected document types are resolved from their stored keys/UDIs to content-type aliases (via `IContentTypeService`) and matched, case-insensitively, against each node's `ContentType.Alias`.

<img width="798" height="943" alt="image" src="https://github.com/user-attachments/assets/e42a9c43-9bc5-48fe-ac65-176fe1f9c8df" />

<img width="789" height="948" alt="image" src="https://github.com/user-attachments/assets/2552c2bd-aa37-44fc-8a8d-945ecc190778" />



**Motivation:** previously the Umbraco Content data source returned _every_ child of the configured parent node, regardless of its document type. This makes it possible to restrict a list/picker to only the relevant node types without needing a custom data source.

**Implementation notes:**

- New `ContentmentConfigurationField` with key `documentType`, using the `Umb.PropertyEditorUi.DocumentTypePicker` UI.
- Two private helpers added to `UmbracoContentDataListSource`:
  - `GetDocumentTypeFilter(...)` — reads the config value (a JSON array of UDIs/keys, or a single token), resolves each to a content-type alias, and returns a case-insensitive `ISet<string>` (or `null` when no filter is configured).
  - `FilterByDocumentType(...)` — applies the alias set to a sequence of `IPublishedContent`, returning the input unchanged when no filter is set.
- The change is contained to a single file: `src/Umbraco.Community.Contentment/DataEditors/DataList/DataSources/UmbracoContentDataListSource.cs` (+94 / −4). No constructor or DI changes — `IContentTypeService` and `IJsonSerializer` were already injected.
- No NuGet dependencies were added or upgraded, and no licensing/copyright information was modified.

### Related Issues?

Sorry I didn't raise an issue for this. I was going to just create a custom data source list for my project and thought it would be better to contribute it to the main project.

### Types of changes

- [ ] Documentation change
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.