### PR TITLE
Expose the current ContentType key to Data List/Picker data sources

### DIFF
--- a/src/Umbraco.Community.Contentment.Client/src/api/types.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/api/types.ts
@@ -136,6 +136,7 @@ export type PostDataListEditorData = {
 	body?: DataListConfigurationRequestModel;
 	path?: never;
 	query?: never;
+	contentTypeKey?: string | null;
 	url: '/umbraco/management/api/v1/contentment/data-list/editor';
 };
 export type PostDataListEditorErrors = ApiErrorStatuses;

--- a/src/Umbraco.Community.Contentment.Client/src/api/types.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/api/types.ts
@@ -21,6 +21,7 @@ export type ContentmentSettings = {
 
 export type DataListConfigurationRequestModel = {
 	alias?: string | null;
+	contentTypeKey?: string | null;
 	dataSource?: ConfigurationEditorItemRequestModel | null;
 	id?: string | null;
 	isNew?: boolean | null;
@@ -46,6 +47,7 @@ export type DataListItem = {
 
 export type DataPickerEditorRequestModel = {
 	alias?: string | null;
+	contentTypeKey?: string | null;
 	dataSource?: ConfigurationEditorItemRequestModel | null;
 	dataTypeKey: string;
 	displayMode?: ConfigurationEditorItemRequestModel | null;
@@ -136,7 +138,6 @@ export type PostDataListEditorData = {
 	body?: DataListConfigurationRequestModel;
 	path?: never;
 	query?: never;
-	contentTypeKey?: string | null;
 	url: '/umbraco/management/api/v1/contentment/data-list/editor';
 };
 export type PostDataListEditorErrors = ApiErrorStatuses;
@@ -190,6 +191,7 @@ export type PostDataPickerSearchData = {
 		variant?: string;
 		parentId?: string;
 		isNew?: boolean;
+		contentTypeKey?: string;
 	};
 	url: '/umbraco/management/api/v1/contentment/data-picker/search';
 };

--- a/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/data-list/data-list.element.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/data-list/data-list.element.ts
@@ -53,7 +53,7 @@ export class ContentmentPropertyEditorUIDataListElement
 	private _listEditor?: ContentmentConfigurationEditorValue;
 
 	@state()
-    private _contentTypeUnique?: string | null;
+	private _contentTypeUnique?: string | null;
 
 	@property({ type: Boolean })
 	mandatory = false;
@@ -81,7 +81,10 @@ export class ContentmentPropertyEditorUIDataListElement
 		this.consumeContext(UMB_CONTENT_WORKSPACE_CONTEXT, (contentWorkspaceContext) => {
 			this.observe(contentWorkspaceContext?.isNew, (isNew) => (this._entityIsNew = isNew ?? false));
 			this.observe(contentWorkspaceContext?.unique, (unique) => (this._entityUnique = unique));
-			this.observe(contentWorkspaceContext?.structure.ownerContentType, (contentType) => (this._contentTypeUnique = contentType?.unique));
+			this.observe(
+				contentWorkspaceContext?.structure.ownerContentTypeObservablePart((x) => x?.unique),
+				(unique) => (this._contentTypeUnique = unique),
+			);
 		}).passContextAliasMatches();
 
 		this.consumeContext(UMB_PARENT_ENTITY_CONTEXT, (parentEntityContext) => {

--- a/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/data-list/data-list.element.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/data-list/data-list.element.ts
@@ -9,7 +9,6 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_CONTENT_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/content';
 import { UMB_PARENT_ENTITY_CONTEXT } from '@umbraco-cms/backoffice/entity';
 import { UMB_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/property';
-import { UMB_DOCUMENT_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/document';
 import type { ContentmentConfigurationEditorValue, ContentmentDataListEditor } from '../types.js';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/property-editor';
 
@@ -82,6 +81,7 @@ export class ContentmentPropertyEditorUIDataListElement
 		this.consumeContext(UMB_CONTENT_WORKSPACE_CONTEXT, (contentWorkspaceContext) => {
 			this.observe(contentWorkspaceContext?.isNew, (isNew) => (this._entityIsNew = isNew ?? false));
 			this.observe(contentWorkspaceContext?.unique, (unique) => (this._entityUnique = unique));
+			this.observe(contentWorkspaceContext?.structure.ownerContentType, (contentType) => (this._contentTypeUnique = contentType?.unique));
 		}).passContextAliasMatches();
 
 		this.consumeContext(UMB_PARENT_ENTITY_CONTEXT, (parentEntityContext) => {
@@ -92,13 +92,6 @@ export class ContentmentPropertyEditorUIDataListElement
 			this.#propertyContext = propertyContext;
 			this.observe(propertyContext?.alias, (alias) => (this._propertyAlias = alias));
 			this.observe(propertyContext?.variantId, (variantId) => (this._variantId = variantId?.toString() || 'invariant'));
-		});
-
-		this.consumeContext(UMB_DOCUMENT_WORKSPACE_CONTEXT, (documentWorkspaceContext) => {
-			this.observe(
-				documentWorkspaceContext?.contentTypeUnique,
-				(contentTypeUnique) => (this._contentTypeUnique = contentTypeUnique),
-			);
 		});
 
 		this.addValidator(

--- a/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/data-list/data-list.element.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/data-list/data-list.element.ts
@@ -9,6 +9,7 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_CONTENT_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/content';
 import { UMB_PARENT_ENTITY_CONTEXT } from '@umbraco-cms/backoffice/entity';
 import { UMB_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/property';
+import { UMB_DOCUMENT_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/document';
 import type { ContentmentConfigurationEditorValue, ContentmentDataListEditor } from '../types.js';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/property-editor';
 
@@ -52,6 +53,9 @@ export class ContentmentPropertyEditorUIDataListElement
 	@state()
 	private _listEditor?: ContentmentConfigurationEditorValue;
 
+	@state()
+    private _contentTypeUnique?: string | null;
+
 	@property({ type: Boolean })
 	mandatory = false;
 
@@ -90,6 +94,13 @@ export class ContentmentPropertyEditorUIDataListElement
 			this.observe(propertyContext?.variantId, (variantId) => (this._variantId = variantId?.toString() || 'invariant'));
 		});
 
+		this.consumeContext(UMB_DOCUMENT_WORKSPACE_CONTEXT, (documentWorkspaceContext) => {
+			this.observe(
+				documentWorkspaceContext?.contentTypeUnique,
+				(contentTypeUnique) => (this._contentTypeUnique = contentTypeUnique),
+			);
+		});
+
 		this.addValidator(
 			'valueMissing',
 			() => this.mandatoryMessage ?? UMB_VALIDATION_EMPTY_LOCALIZATION_KEY,
@@ -123,6 +134,7 @@ export class ContentmentPropertyEditorUIDataListElement
 			parentEntityUnique: this._parentEntityUnique,
 			propertyAlias: this._propertyAlias,
 			variantId: this._variantId,
+			contentTypeUnique: this._contentTypeUnique,
 		});
 
 		const combinedConfig = [...(this.#listEditor?.config ?? []), ...(this.config ?? [])];

--- a/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/data-list/data-list.element.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/data-list/data-list.element.ts
@@ -125,12 +125,12 @@ export class ContentmentPropertyEditorUIDataListElement
 		this.#listEditor = await this.#repository.__getEditorInternal({
 			dataSource: this._dataSource,
 			listEditor: this._listEditor,
+			contentTypeUnique: this._contentTypeUnique,
 			entityIsNew: this._entityIsNew,
 			entityUnique: this._entityUnique,
 			parentEntityUnique: this._parentEntityUnique,
 			propertyAlias: this._propertyAlias,
 			variantId: this._variantId,
-			contentTypeUnique: this._contentTypeUnique,
 		});
 
 		const combinedConfig = [...(this.#listEditor?.config ?? []), ...(this.config ?? [])];

--- a/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/data-list/data-list.repository.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/data-list/data-list.repository.ts
@@ -18,12 +18,12 @@ import type { ContentmentListItem } from '../types.js';
 export type ContentmentDataListRepositoryGetEditorArgs = {
 	dataSource?: ContentmentConfigurationEditorValue | null;
 	listEditor?: ContentmentConfigurationEditorValue | null;
+	contentTypeUnique?: string | null;
 	entityIsNew?: boolean;
 	entityUnique?: string | null;
 	parentEntityUnique?: string | null;
 	propertyAlias?: string | null;
 	variantId?: string | null;
-	contentTypeUnique?: string | null;
 };
 
 export class ContentmentDataListRepository extends UmbRepositoryBase implements UmbApi {

--- a/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/data-list/data-list.repository.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/data-list/data-list.repository.ts
@@ -82,13 +82,13 @@ export class ContentmentDataListRepository extends UmbRepositoryBase implements 
 
 		const body = {
 			alias: args.propertyAlias,
+			contentTypeKey: args.contentTypeUnique,
 			dataSource: args.dataSource,
 			id: args.entityUnique,
 			isNew: args.entityIsNew,
 			listEditor: args.listEditor,
 			parentId: args.parentEntityUnique,
 			variant: args.variantId,
-			contentTypeKey: args.contentTypeUnique,
 		};
 
 		const { data } = await tryExecute(this, DataListService.postDataListEditor({ body }));

--- a/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/data-list/data-list.repository.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/data-list/data-list.repository.ts
@@ -23,6 +23,7 @@ export type ContentmentDataListRepositoryGetEditorArgs = {
 	parentEntityUnique?: string | null;
 	propertyAlias?: string | null;
 	variantId?: string | null;
+	contentTypeUnique?: string | null;
 };
 
 export class ContentmentDataListRepository extends UmbRepositoryBase implements UmbApi {
@@ -87,6 +88,7 @@ export class ContentmentDataListRepository extends UmbRepositoryBase implements 
 			listEditor: args.listEditor,
 			parentId: args.parentEntityUnique,
 			variant: args.variantId,
+			contentTypeKey: args.contentTypeUnique,
 		};
 
 		const { data } = await tryExecute(this, DataListService.postDataListEditor({ body }));

--- a/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/data-picker/data-picker-modal.element.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/data-picker/data-picker-modal.element.ts
@@ -93,12 +93,19 @@ export class ContentmentPropertyEditorUIDataPickerModalElement extends UmbModalB
 	@state()
 	private _variantId?: string;
 
+	@state()
+	private _contentTypeUnique?: string | null;
+
 	constructor() {
 		super();
 
 		this.consumeContext(UMB_CONTENT_WORKSPACE_CONTEXT, (contentWorkspaceContext) => {
 			this.observe(contentWorkspaceContext?.isNew, (isNew) => (this._entityIsNew = isNew ?? false));
 			this.observe(contentWorkspaceContext?.unique, (unique) => (this._entityUnique = unique || undefined));
+			this.observe(
+				contentWorkspaceContext?.structure.ownerContentTypeObservablePart((x) => x?.unique),
+				(unique) => (this._contentTypeUnique = unique),
+			);
 		}).passContextAliasMatches();
 
 		this.consumeContext(UMB_PARENT_ENTITY_CONTEXT, (parentEntityContext) => {
@@ -167,6 +174,7 @@ export class ContentmentPropertyEditorUIDataPickerModalElement extends UmbModalB
 
 		const query = {
 			alias: this._propertyAlias,
+			contentTypeKey: this._contentTypeUnique ?? undefined,
 			dataTypeKey: this._dataTypeKey,
 			id: this._entityUnique,
 			isNew: this._entityIsNew,

--- a/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/data-picker/data-picker.element.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/property-editor-ui/data-picker/data-picker.element.ts
@@ -75,6 +75,9 @@ export class ContentmentPropertyEditorUIDataPickerElement extends UmbLitElement 
 	@state()
 	private _variantId?: string;
 
+	@state()
+	private _contentTypeUnique?: string | null;
+
 	@property({ type: Array })
 	public set value(value: Array<string> | string | undefined) {
 		this.#value = Array.isArray(value) ? value : value ? [value] : [];
@@ -106,6 +109,10 @@ export class ContentmentPropertyEditorUIDataPickerElement extends UmbLitElement 
 		this.consumeContext(UMB_CONTENT_WORKSPACE_CONTEXT, (contentWorkspaceContext) => {
 			this.observe(contentWorkspaceContext?.isNew, (isNew) => (this._entityIsNew = isNew ?? false));
 			this.observe(contentWorkspaceContext?.unique, (unique) => (this._entityUnique = unique));
+			this.observe(
+				contentWorkspaceContext?.structure.ownerContentTypeObservablePart((x) => x?.unique),
+				(unique) => (this._contentTypeUnique = unique),
+			);
 		}).passContextAliasMatches();
 
 		this.consumeContext(UMB_PARENT_ENTITY_CONTEXT, (parentEntityContext) => {
@@ -132,6 +139,7 @@ export class ContentmentPropertyEditorUIDataPickerElement extends UmbLitElement 
 
 		const body = {
 			alias: this._propertyAlias,
+			contentTypeKey: this._contentTypeUnique,
 			dataTypeKey: this._dataTypeKey,
 			dataSource: this._dataSource,
 			displayMode: this._displayMode,

--- a/src/Umbraco.Community.Contentment/Api/Management/Controllers/ContentmentControllerBase.cs
+++ b/src/Umbraco.Community.Contentment/Api/Management/Controllers/ContentmentControllerBase.cs
@@ -21,7 +21,8 @@ public abstract class ContentmentControllerBase : ManagementApiControllerBase
         string? parentId = null,
         string? variantId = null,
         string? propertyAlias = null,
-        bool? isNew = false)
+        bool? isNew = false,
+        string? contentTypeKey = null)
     {
         if (string.IsNullOrWhiteSpace(propertyAlias) == false)
         {
@@ -41,6 +42,13 @@ public abstract class ContentmentControllerBase : ManagementApiControllerBase
         if (string.IsNullOrWhiteSpace(parentId) == false)
         {
             HttpContext.Items.Add("contentmentContextCurrentParentId", parentId);
+        }
+
+        if (string.IsNullOrWhiteSpace(contentTypeKey) == false)
+        {
+            HttpContext.Items.Add(
+                "contentmentContextCurrentContentTypeKey",
+                contentTypeKey);
         }
 
         HttpContext.Items.Add("contentmentContextCurrentIsNew", isNew ?? false);

--- a/src/Umbraco.Community.Contentment/Api/Management/Controllers/ContentmentControllerBase.cs
+++ b/src/Umbraco.Community.Contentment/Api/Management/Controllers/ContentmentControllerBase.cs
@@ -22,7 +22,7 @@ public abstract class ContentmentControllerBase : ManagementApiControllerBase
         string? variantId = null,
         string? propertyAlias = null,
         bool? isNew = false,
-        string? contentTypeKey = null)
+        Guid? contentTypeKey = null)
     {
         if (string.IsNullOrWhiteSpace(propertyAlias) == false)
         {
@@ -44,11 +44,9 @@ public abstract class ContentmentControllerBase : ManagementApiControllerBase
             HttpContext.Items.Add("contentmentContextCurrentParentId", parentId);
         }
 
-        if (string.IsNullOrWhiteSpace(contentTypeKey) == false)
+        if (contentTypeKey.HasValue == true && contentTypeKey.Value != Guid.Empty)
         {
-            HttpContext.Items.Add(
-                "contentmentContextCurrentContentTypeKey",
-                contentTypeKey);
+            HttpContext.Items.Add("contentmentContextCurrentContentTypeKey", contentTypeKey.Value);
         }
 
         HttpContext.Items.Add("contentmentContextCurrentIsNew", isNew ?? false);

--- a/src/Umbraco.Community.Contentment/Api/Management/Controllers/DataList/DataListConfigurationRequestModel.cs
+++ b/src/Umbraco.Community.Contentment/Api/Management/Controllers/DataList/DataListConfigurationRequestModel.cs
@@ -7,6 +7,8 @@ public sealed class DataListConfigurationRequestModel
 {
     public string? Alias { get; set; }
 
+    public Guid? ContentTypeKey { get; set; }
+
     public ConfigurationEditorItemRequestModel? DataSource { get; set; }
 
     public string? Id { get; set; }
@@ -18,6 +20,4 @@ public sealed class DataListConfigurationRequestModel
     public ConfigurationEditorItemRequestModel? ListEditor { get; set; }
 
     public string? Variant { get; set; }
-
-    public string? ContentTypeKey { get; set; }
 }

--- a/src/Umbraco.Community.Contentment/Api/Management/Controllers/DataList/DataListConfigurationRequestModel.cs
+++ b/src/Umbraco.Community.Contentment/Api/Management/Controllers/DataList/DataListConfigurationRequestModel.cs
@@ -18,4 +18,6 @@ public sealed class DataListConfigurationRequestModel
     public ConfigurationEditorItemRequestModel? ListEditor { get; set; }
 
     public string? Variant { get; set; }
+
+    public string? ContentTypeKey { get; set; }
 }

--- a/src/Umbraco.Community.Contentment/Api/Management/Controllers/DataList/DataListController.cs
+++ b/src/Umbraco.Community.Contentment/Api/Management/Controllers/DataList/DataListController.cs
@@ -26,7 +26,7 @@ public class DataListController : ContentmentControllerBase
         // NOTE: A placeholder async task, until I get async working throughout the codebase. ¯\_(ツ)_/¯
         await Task.Run(() => { });
 
-        SetCurrentContentContextValues(model.Id, model.ParentId, model.Variant, model.Alias, model.IsNew, contentTypeKey: model.ContentTypeKey);
+        SetCurrentContentContextValues(model.Id, model.ParentId, model.Variant, model.Alias, model.IsNew, model.ContentTypeKey);
 
         var propertyEditorUiAlias = string.Empty;
 

--- a/src/Umbraco.Community.Contentment/Api/Management/Controllers/DataList/DataListController.cs
+++ b/src/Umbraco.Community.Contentment/Api/Management/Controllers/DataList/DataListController.cs
@@ -26,7 +26,7 @@ public class DataListController : ContentmentControllerBase
         // NOTE: A placeholder async task, until I get async working throughout the codebase. ¯\_(ツ)_/¯
         await Task.Run(() => { });
 
-        SetCurrentContentContextValues(model.Id, model.ParentId, model.Variant, model.Alias, model.IsNew);
+        SetCurrentContentContextValues(model.Id, model.ParentId, model.Variant, model.Alias, model.IsNew, contentTypeKey: model.ContentTypeKey);
 
         var propertyEditorUiAlias = string.Empty;
 

--- a/src/Umbraco.Community.Contentment/Api/Management/Controllers/DataPicker/DataPickerController.cs
+++ b/src/Umbraco.Community.Contentment/Api/Management/Controllers/DataPicker/DataPickerController.cs
@@ -35,7 +35,7 @@ public class DataPickerController : ContentmentControllerBase
     [MapToApiVersion("1.0")]
     public async Task<IActionResult> GetEditor(DataPickerEditorRequestModel model)
     {
-        SetCurrentContentContextValues(model.Id, model.ParentId, model.Variant, model.Alias, model.IsNew);
+        SetCurrentContentContextValues(model.Id, model.ParentId, model.Variant, model.Alias, model.IsNew, model.ContentTypeKey);
 
         var propertyEditorUiAlias = string.Empty;
 
@@ -106,7 +106,7 @@ public class DataPickerController : ContentmentControllerBase
         string query = "",
         string? alias = default,
         string? variant = default)
-            => await Search(id, dataTypeKey, pageNumber, pageSize, query, alias, variant, null, false, []);
+            => await Search(id, dataTypeKey, pageNumber, pageSize, query, alias, variant, null, false, null, []);
 
     [HttpPost("search", Name = "PostDataPickerSearch")]
     [MapToApiVersion("1.0")]
@@ -120,9 +120,10 @@ public class DataPickerController : ContentmentControllerBase
         string? variant = default,
         string? parentId = default,
         bool? isNew = false,
+        Guid? contentTypeKey = default,
         [FromBody] string[]? values = null)
     {
-        SetCurrentContentContextValues(id, parentId, variant, alias, isNew);
+        SetCurrentContentContextValues(id, parentId, variant, alias, isNew, contentTypeKey);
 
         if (_lookup.TryGetValue(dataTypeKey, out var cached) == true)
         {

--- a/src/Umbraco.Community.Contentment/Api/Management/Controllers/DataPicker/DataPickerEditorRequestModel.cs
+++ b/src/Umbraco.Community.Contentment/Api/Management/Controllers/DataPicker/DataPickerEditorRequestModel.cs
@@ -7,6 +7,8 @@ public sealed class DataPickerEditorRequestModel
 {
     public string? Alias { get; set; }
 
+    public Guid? ContentTypeKey { get; set; }
+
     public ConfigurationEditorItemRequestModel? DataSource { get; set; }
 
     public Guid DataTypeKey { get; set; }

--- a/src/Umbraco.Community.Contentment/Services/ContentmentContentContext.cs
+++ b/src/Umbraco.Community.Contentment/Services/ContentmentContentContext.cs
@@ -105,14 +105,13 @@ namespace Umbraco.Community.Contentment.Services
 
         public Guid? GetCurrentContentTypeKey()
         {
-            if (_httpContextAccessor.HttpContext?.Items.TryGetValueAs(
-                    "contentmentContextCurrentContentTypeKey",
-                    out Guid? contentTypeKey) == true)
+            if (_httpContextAccessor.HttpContext?.Items.TryGetValueAs("contentmentContextCurrentContentTypeKey", out Guid? contentTypeKey) == true &&
+                contentTypeKey.HasValue == true)
             {
                 return contentTypeKey;
             }
 
-            return null;
+            return GetCurrentContent(out _)?.ContentType.Key;
         }
 
         private void SetVariationContext()

--- a/src/Umbraco.Community.Contentment/Services/ContentmentContentContext.cs
+++ b/src/Umbraco.Community.Contentment/Services/ContentmentContentContext.cs
@@ -10,7 +10,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Community.Contentment.Services
 {
-    public sealed class ContentmentContentContext : IContentmentContentContext3
+    public sealed class ContentmentContentContext : IContentmentContentContext4
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IUmbracoContextAccessor _umbracoContextAccessor;
@@ -101,6 +101,18 @@ namespace Umbraco.Community.Contentment.Services
             }
 
             return default;
+        }
+
+        public Guid? GetCurrentContentTypeKey()
+        {
+            if (_httpContextAccessor.HttpContext?.Items.TryGetValueAs(
+                    "contentmentContextCurrentContentTypeKey",
+                    out Guid? contentTypeKey) == true)
+            {
+                return contentTypeKey;
+            }
+
+            return null;
         }
 
         private void SetVariationContext()

--- a/src/Umbraco.Community.Contentment/Services/ContentmentContentContextExtensions.cs
+++ b/src/Umbraco.Community.Contentment/Services/ContentmentContentContextExtensions.cs
@@ -10,7 +10,7 @@ namespace Umbraco.Community.Contentment.Services
     public static class ContentmentContentContextExtensions
     {
         public static int? GetCurrentContentId(this IContentmentContentContext ctx) => ctx.GetCurrentContentId(out _);
-
+        public static Guid? GetCurrentContentTypeKey(this IContentmentContentContext ctx) => ctx.GetCurrentContentTypeKey();
         public static IPublishedContent? GetCurrentContent(this IContentmentContentContext ctx) => ctx.GetCurrentContent(out _);
 
         [Obsolete("To be removed in Contentment 8.0")]

--- a/src/Umbraco.Community.Contentment/Services/ContentmentContentContextExtensions.cs
+++ b/src/Umbraco.Community.Contentment/Services/ContentmentContentContextExtensions.cs
@@ -10,8 +10,10 @@ namespace Umbraco.Community.Contentment.Services
     public static class ContentmentContentContextExtensions
     {
         public static int? GetCurrentContentId(this IContentmentContentContext ctx) => ctx.GetCurrentContentId(out _);
-        public static Guid? GetCurrentContentTypeKey(this IContentmentContentContext ctx) => (ctx as IContentmentContentContext4)?.GetCurrentContentTypeKey();
         public static IPublishedContent? GetCurrentContent(this IContentmentContentContext ctx) => ctx.GetCurrentContent(out _);
+
+        public static Guid? GetCurrentContentTypeKey(this IContentmentContentContext ctx)
+            => (ctx as IContentmentContentContext4)?.GetCurrentContentTypeKey();
 
         [Obsolete("To be removed in Contentment 8.0")]
         public static string ParseXPathQuery(
@@ -27,10 +29,10 @@ namespace Umbraco.Community.Contentment.Services
                 xpathExpression = xpathExpression.Replace("$parent", $"id({nodeContextId})");
             }
 
-//#pragma warning disable CS0618 // Type or member is obsolete
-//            return UmbracoXPathPathSyntaxParser.ParseXPathQuery(xpathExpression, nodeContextId, getPath, publishedContentExists);
+            //#pragma warning disable CS0618 // Type or member is obsolete
+            //            return UmbracoXPathPathSyntaxParser.ParseXPathQuery(xpathExpression, nodeContextId, getPath, publishedContentExists);
             return xpathExpression;
-//#pragma warning restore CS0618 // Type or member is obsolete
+            //#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/src/Umbraco.Community.Contentment/Services/ContentmentContentContextExtensions.cs
+++ b/src/Umbraco.Community.Contentment/Services/ContentmentContentContextExtensions.cs
@@ -10,7 +10,7 @@ namespace Umbraco.Community.Contentment.Services
     public static class ContentmentContentContextExtensions
     {
         public static int? GetCurrentContentId(this IContentmentContentContext ctx) => ctx.GetCurrentContentId(out _);
-        public static Guid? GetCurrentContentTypeKey(this IContentmentContentContext ctx) => ctx.GetCurrentContentTypeKey();
+        public static Guid? GetCurrentContentTypeKey(this IContentmentContentContext ctx) => (ctx as IContentmentContentContext4)?.GetCurrentContentTypeKey();
         public static IPublishedContent? GetCurrentContent(this IContentmentContentContext ctx) => ctx.GetCurrentContent(out _);
 
         [Obsolete("To be removed in Contentment 8.0")]

--- a/src/Umbraco.Community.Contentment/Services/ContentmentContentContextExtensions.cs
+++ b/src/Umbraco.Community.Contentment/Services/ContentmentContentContextExtensions.cs
@@ -29,10 +29,10 @@ namespace Umbraco.Community.Contentment.Services
                 xpathExpression = xpathExpression.Replace("$parent", $"id({nodeContextId})");
             }
 
-            //#pragma warning disable CS0618 // Type or member is obsolete
-            //            return UmbracoXPathPathSyntaxParser.ParseXPathQuery(xpathExpression, nodeContextId, getPath, publishedContentExists);
+//#pragma warning disable CS0618 // Type or member is obsolete
+//            return UmbracoXPathPathSyntaxParser.ParseXPathQuery(xpathExpression, nodeContextId, getPath, publishedContentExists);
             return xpathExpression;
-            //#pragma warning restore CS0618 // Type or member is obsolete
+//#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/src/Umbraco.Community.Contentment/Services/IContentmentContentContext.cs
+++ b/src/Umbraco.Community.Contentment/Services/IContentmentContentContext.cs
@@ -31,6 +31,8 @@ namespace Umbraco.Community.Contentment.Services
         string? GetCurrentVariantId();
     }
 
+    // NOTE: Added as a separate interface, so not to break binary backwards-compatibility. [EW]
+    [Obsolete("To be combined with `IContentmentContentContext`. This interface will be removed in Contentment 8.0.")]
     public interface IContentmentContentContext4
     : IContentmentContentContext3
     {

--- a/src/Umbraco.Community.Contentment/Services/IContentmentContentContext.cs
+++ b/src/Umbraco.Community.Contentment/Services/IContentmentContentContext.cs
@@ -30,9 +30,12 @@ namespace Umbraco.Community.Contentment.Services
 
     // NOTE: Added as a separate interface, so not to break binary backwards-compatibility. [EW]
     [Obsolete("To be combined with `IContentmentContentContext`. This interface will be removed in Contentment 8.0.")]
-    public interface IContentmentContentContext4
-    : IContentmentContentContext3
+    public interface IContentmentContentContext4 : IContentmentContentContext3
     {
-        Guid? GetCurrentContentTypeKey();
+        /// <summary>
+        /// Gets the content type key of the current content, e.g. a document type, media type or member type.
+        /// </summary>
+        /// <returns>The content type key, or <see langword="null"/> if it could not be resolved.</returns>
+        public Guid? GetCurrentContentTypeKey();
     }
 }

--- a/src/Umbraco.Community.Contentment/Services/IContentmentContentContext.cs
+++ b/src/Umbraco.Community.Contentment/Services/IContentmentContentContext.cs
@@ -11,7 +11,10 @@ namespace Umbraco.Community.Contentment.Services
     {
         int? GetCurrentContentId(out bool isParent);
 
+        Guid? GetCurrentContentTypeKey();
+
         IPublishedContent? GetCurrentContent(out bool isParent);
+
     }
 
     // NOTE: Added as a separate interface, so not to break binary backwards-compatibility. [LK]
@@ -26,5 +29,11 @@ namespace Umbraco.Community.Contentment.Services
     public interface IContentmentContentContext3 : IContentmentContentContext2
     {
         string? GetCurrentVariantId();
+    }
+
+    public interface IContentmentContentContext4
+    : IContentmentContentContext3
+    {
+        Guid? GetCurrentContentTypeKey();
     }
 }

--- a/src/Umbraco.Community.Contentment/Services/IContentmentContentContext.cs
+++ b/src/Umbraco.Community.Contentment/Services/IContentmentContentContext.cs
@@ -11,10 +11,7 @@ namespace Umbraco.Community.Contentment.Services
     {
         int? GetCurrentContentId(out bool isParent);
 
-        Guid? GetCurrentContentTypeKey();
-
         IPublishedContent? GetCurrentContent(out bool isParent);
-
     }
 
     // NOTE: Added as a separate interface, so not to break binary backwards-compatibility. [LK]


### PR DESCRIPTION
## Description

This PR makes the document type key of the current document available to context-aware Data List data sources through `IContentmentContentContext`.

When creating a new document, `GetCurrentContent()` returns the parent document because the new document has not yet been persisted or published. As a result, a Data List data source receives the content type of the parent instead of the document being created.

The Umbraco document workspace already exposes the correct document type key through `contentTypeUnique`. This PR passes that value from the Data List property editor to the Contentment Management API and makes it available through the content context.

## Changes

* Read `contentTypeUnique` from `UMB_DOCUMENT_WORKSPACE_CONTEXT`.
* Include the document type key in the Data List editor request.
* Store the document type key in the current HTTP request context.
* Expose the value through `IContentmentContentContext`.
* Add a new version of the context interface to preserve binary backwards compatibility.

This allows context-aware Data List data sources to retrieve the correct document type key for both existing documents and new documents that have not yet been saved.

This change currently applies to Data Lists only.
