### PR TITLE
Conditional code to hide the uuiBox in the case that no properties are visible within it

### DIFF
--- a/src/Umbraco.Community.Contentment.Client/src/utils/move-before-property-group.function.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/utils/move-before-property-group.function.ts
@@ -9,7 +9,7 @@ export function tryMoveBeforePropertyGroup(element: UmbPropertyEditorUiElement):
 		const umbProperty = closest('umb-property', element) as HTMLElement;
 		if (!umbProperty) return;
 
-		const uuiBox = closest('uui-box', umbProperty);
+		const uuiBox = closest('uui-box', umbProperty) as HTMLElement;
 		if (!uuiBox) return;
 
 		const umbContentWorkspaceViewEditTab = closest('umb-content-workspace-view-edit-tab', uuiBox);
@@ -17,5 +17,13 @@ export function tryMoveBeforePropertyGroup(element: UmbPropertyEditorUiElement):
 
 		umbContentWorkspaceViewEditTab.shadowRoot?.insertBefore(element, uuiBox);
 		umbProperty.style.display = 'none';
+
+		const hasVisibleProperty = Array.from(uuiBox.querySelectorAll('umb-property')).some(
+			(property) => (property as HTMLElement).style.display !== 'none',
+		);
+
+		if (!hasVisibleProperty) {
+			uuiBox.style.display = 'none';
+		}
 	}
 }

--- a/src/Umbraco.Community.Contentment.Client/src/utils/move-before-property-group.function.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/utils/move-before-property-group.function.ts
@@ -6,12 +6,15 @@ import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/propert
 
 export function tryMoveBeforePropertyGroup(element: UmbPropertyEditorUiElement): void {
 	if (element) {
+		// Find the `umb-property` hosting this editor, so it can be hidden once its content is moved out.
 		const umbProperty = closest('umb-property', element) as HTMLElement;
 		if (!umbProperty) return;
 
+		// Find the group's `uui-box`, so the element can be moved above it, and hidden later if it ends up empty.
 		const uuiBox = closest('uui-box', umbProperty) as HTMLElement;
 		if (!uuiBox) return;
 
+		// Find the tab hosting the box, so we can reach its shadow root and insert the element into it.
 		const umbContentWorkspaceViewEditTab = closest('umb-content-workspace-view-edit-tab', uuiBox);
 		if (!umbContentWorkspaceViewEditTab) return;
 

--- a/src/Umbraco.Community.Contentment.Client/src/utils/move-before-property-group.function.ts
+++ b/src/Umbraco.Community.Contentment.Client/src/utils/move-before-property-group.function.ts
@@ -16,9 +16,16 @@ export function tryMoveBeforePropertyGroup(element: UmbPropertyEditorUiElement):
 		if (!umbContentWorkspaceViewEditTab) return;
 
 		umbContentWorkspaceViewEditTab.shadowRoot?.insertBefore(element, uuiBox);
-		umbProperty.style.display = 'none';
 
-		const hasVisibleProperty = Array.from(uuiBox.querySelectorAll('umb-property')).some(
+		// Hide the outermost per-property wrapper (not just `umb-property`), so its divider is hidden too.
+		const workspaceProperty = closest('umb-content-workspace-property', umbProperty) as HTMLElement;
+		(workspaceProperty ?? umbProperty).style.display = 'none';
+		if (!workspaceProperty) return;
+
+		// `umb-property` sits behind several shadow roots below `uui-box`, so `querySelectorAll` can't see it from here.
+		// Query siblings from the wrapper's own parent instead, and hide the box once none remain visible.
+		const workspaceProperties = workspaceProperty.parentNode?.querySelectorAll('umb-content-workspace-property') ?? [];
+		const hasVisibleProperty = Array.from(workspaceProperties).some(
 			(property) => (property as HTMLElement).style.display !== 'none',
 		);
 


### PR DESCRIPTION
Conditional code to hide the uuiBox in the case that no properties are visible within it

### Description

`hidePropertyGroup` moves the note above its group and hides the `umb-property`, but never hides the uui-box. Where the note is the only property in that group, the emptied box still renders as a titled section — which reads to editors as missing content rather than as a layout artefact.

This fix hides the box as well, but only when no visible properties remain, so groups containing other properties are unaffected.

Spotted on 6.3.0 / Umbraco 17.6.0.

This is what currently displays on my test case:
<img width="574" height="311" alt="image" src="https://github.com/user-attachments/assets/f3690f70-6eff-450a-972e-986f91c03eb3" />

### Types of changes

- [ ] Documentation change
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
